### PR TITLE
fix(desktop): 설정 동기화 시 block_quic 필드 누락 수정

### DIFF
--- a/desktop/src-tauri/src/proxy_v2/proxy_control.rs
+++ b/desktop/src-tauri/src/proxy_v2/proxy_control.rs
@@ -276,11 +276,16 @@ async fn sync_stored_settings_to_daemon<R: Runtime>(app: &AppHandle<R>, sender: 
             .get("quickSettingsNoGzip")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let block_quic = settings
+            .get("quickSettingsBlockQuic")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         if let Err(e) = sender
             .send_command(&ClientCommand::UpdateQuickSettings {
                 no_caching,
                 block_cookies,
                 no_gzip,
+                block_quic,
             })
             .await
         {


### PR DESCRIPTION
## 개요

`ClientCommand::UpdateQuickSettings` 구조체 초기화 시 `block_quic` 필드가 누락되어 컴파일 오류가 발생하는 문제를 수정한다.

## 변경 내용

### 수정된 파일

- `desktop/src-tauri/src/proxy_v2/proxy_control.rs` — `sync_stored_settings_to_daemon` 함수에서 `quickSettingsBlockQuic` 설정값을 읽어 `block_quic` 필드로 전달하도록 추가. 다른 quick settings 필드(`no_caching`, `block_cookies`, `no_gzip`)와 동일한 패턴 적용.

## 구현 상세

`block_quic` 필드는 이미 `ClientCommand::UpdateQuickSettings` 열거형에 정의되어 있고, `settings.rs`의 tauri command 핸들러에서는 올바르게 전달하고 있었으나, `proxy_control.rs`의 설정 동기화 경로에서만 누락된 상태였다.

## 테스트

- [ ] `cargo check` 컴파일 오류 해소 확인
- [ ] 데스크톱 앱 실행 후 Block QUIC 설정이 데몬에 정상 동기화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)