### PR TITLE
feat(proxyapi_v2): 인증서 안정화 — Thundering herd 방지, CA 자동 재생성, 키 검증

### DIFF
--- a/crates/proxyapi_v2/src/certificate_authority/generator.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/generator.rs
@@ -6,6 +6,7 @@ use tracing::{info, warn};
 use super::storage::get_ca_storage_dir;
 
 /// CA 인증서 만료 상태
+#[derive(Debug, PartialEq)]
 enum CaExpiryStatus {
     /// 유효
     Valid,
@@ -45,6 +46,13 @@ use tokio_rustls::rustls::pki_types::CertificateDer;
 /// 저장된 인증서를 로드하거나 새로 생성합니다.
 #[cfg(feature = "rcgen-ca")]
 pub fn load_or_generate_ca() -> Result<RcgenAuthority, String> {
+    let (ca, _event) = load_or_generate_ca_with_event()?;
+    Ok(ca)
+}
+
+/// 저장된 인증서를 로드하거나 새로 생성하며, 발생한 이벤트를 함께 반환합니다.
+#[cfg(feature = "rcgen-ca")]
+pub fn load_or_generate_ca_with_event() -> Result<(RcgenAuthority, super::CertEvent), String> {
     let storage_dir = get_ca_storage_dir()?;
     let key_path = storage_dir.join("cheolsu-proxy.key");
     let cer_path = storage_dir.join("cheolsu-proxy.cer");
@@ -55,24 +63,61 @@ pub fn load_or_generate_ca() -> Result<RcgenAuthority, String> {
             match check_cert_expiry(&cert_der) {
                 Some(CaExpiryStatus::Expired) => {
                     info!(path = %storage_dir.display(), "CA 인증서가 만료되었습니다. 새로 생성합니다.");
-                    return generate_and_save_ca(&storage_dir);
+                    let ca = generate_and_save_ca(&storage_dir)?;
+                    return Ok((ca, super::CertEvent::CaRegeneratedExpired));
                 }
                 Some(CaExpiryStatus::ExpiringSoon(days)) => {
                     warn!(
                         remaining_days = days,
-                        "CA 인증서가 곧 만료됩니다. 재생성을 권장합니다."
+                        "CA 인증서가 {}일 후 만료. 자동 재생성합니다.", days
                     );
+                    let ca = generate_and_save_ca(&storage_dir)?;
+                    return Ok((ca, super::CertEvent::CaRegeneratedExpiringSoon(days)));
                 }
                 _ => {}
             }
         }
         info!(path = %storage_dir.display(), "기존 CA 인증서 로드 중");
-        return load_ca_from_storage(&key_path, &cer_path);
+        match load_ca_from_storage(&key_path, &cer_path) {
+            Ok(ca) => return Ok((ca, super::CertEvent::CaLoaded)),
+            Err(e) => {
+                warn!(
+                    "CA 인증서 로드 실패 (손상 또는 키 불일치): {}. 재생성합니다.",
+                    e
+                );
+                let ca = generate_and_save_ca(&storage_dir)?;
+                return Ok((ca, super::CertEvent::CaRegeneratedCorrupted(e)));
+            }
+        }
     }
 
     // 없으면 새로 생성
     info!(path = %storage_dir.display(), "새 CA 인증서 생성 중");
-    generate_and_save_ca(&storage_dir)
+    let ca = generate_and_save_ca(&storage_dir)?;
+    Ok((ca, super::CertEvent::CaGenerated))
+}
+
+/// CA 인증서와 개인키가 매칭되는지 검증합니다.
+/// 인증서의 공개키와 개인키로부터 추출한 공개키를 비교합니다.
+#[cfg(feature = "rcgen-ca")]
+fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<(), String> {
+    use x509_parser::parse_x509_certificate;
+
+    let key_pair =
+        rcgen::KeyPair::from_pem(key_pem).map_err(|e| format!("개인키 파싱 실패: {}", e))?;
+    let (_, cert) =
+        parse_x509_certificate(cert_der).map_err(|e| format!("인증서 파싱 실패: {}", e))?;
+
+    let cert_pub_key = cert.public_key().raw;
+    let key_pub_key = key_pair.public_key_raw();
+
+    // X.509 SubjectPublicKeyInfo의 끝 부분에 실제 공개키 바이트가 포함됨
+    // rcgen의 public_key_raw()는 raw 바이트만 반환하므로 cert의 SPKI에 포함되어 있는지 확인
+    if !cert_pub_key.ends_with(key_pub_key) {
+        return Err("CA 인증서와 개인키가 매칭되지 않습니다. 인증서를 재생성합니다.".to_string());
+    }
+
+    Ok(())
 }
 
 /// 저장된 인증서 파일에서 RcgenAuthority를 로드합니다.
@@ -85,6 +130,9 @@ pub fn load_ca_from_storage(
         fs::read_to_string(key_path).map_err(|e| format!("Failed to read key file: {}", e))?;
     let cert_der =
         fs::read(cer_path).map_err(|e| format!("Failed to read certificate file: {}", e))?;
+
+    // 키-인증서 매칭 검증
+    verify_ca_key_cert_match(&key_pem, &cert_der)?;
 
     let key_pair =
         rcgen::KeyPair::from_pem(&key_pem).map_err(|e| format!("Failed to parse key: {}", e))?;
@@ -256,15 +304,25 @@ pub fn load_or_generate_openssl_ca() -> Result<OpensslAuthority, String> {
                     Some(CaExpiryStatus::ExpiringSoon(days)) => {
                         warn!(
                             remaining_days = days,
-                            "OpenSSL CA 인증서가 곧 만료됩니다. 재생성을 권장합니다."
+                            "OpenSSL CA 인증서가 {}일 후 만료. 자동 재생성합니다.", days
                         );
+                        return generate_openssl_ca(&storage_dir);
                     }
                     _ => {}
                 }
             }
         }
         info!(path = %storage_dir.display(), "기존 OpenSSL 인증서 파일 사용");
-        return load_openssl_ca_from_storage(&key_path, &cer_path);
+        match load_openssl_ca_from_storage(&key_path, &cer_path) {
+            Ok(ca) => return Ok(ca),
+            Err(e) => {
+                warn!(
+                    "OpenSSL CA 로드 실패 (손상 또는 키 불일치): {}. 재생성합니다.",
+                    e
+                );
+                return generate_openssl_ca(&storage_dir);
+            }
+        }
     }
 
     info!("새로운 OpenSSL 인증서 생성");
@@ -296,19 +354,24 @@ pub fn load_openssl_ca_from_storage(
     let ca_cert = X509::from_pem(ca_cert_pem.as_bytes())
         .map_err(|e| format!("Failed to parse CA certificate from PEM: {}", e))?;
 
-    // X509를 PEM으로 변환 (로깅용)
-    let ca_cert_pem_converted = ca_cert
-        .to_pem()
-        .map_err(|e| format!("Failed to convert CA certificate to PEM: {}", e))?;
-
-    info!(
-        size_bytes = ca_cert_pem_converted.len(),
-        "CA 인증서 PEM 파싱 성공"
-    );
-
     // PEM을 PKey로 변환
     let pkey = PKey::private_key_from_pem(private_key_pem.as_bytes())
         .map_err(|e| format!("Failed to parse private key from PEM: {}", e))?;
+
+    // 키-인증서 매칭 검증: 인증서의 공개키와 개인키의 공개키를 비교
+    let cert_pub_key_der = ca_cert
+        .public_key()
+        .map_err(|e| format!("인증서에서 공개키 추출 실패: {}", e))?
+        .public_key_to_der()
+        .map_err(|e| format!("공개키 DER 변환 실패: {}", e))?;
+    let pkey_pub_key_der = pkey
+        .public_key_to_der()
+        .map_err(|e| format!("개인키에서 공개키 DER 변환 실패: {}", e))?;
+    if cert_pub_key_der != pkey_pub_key_der {
+        return Err("OpenSSL CA 인증서와 개인키가 매칭되지 않습니다".to_string());
+    }
+
+    info!("CA 인증서 PEM 파싱 및 키 매칭 검증 성공");
 
     // OpensslAuthority 생성
     Ok(OpensslAuthority::new(
@@ -496,6 +559,50 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_check_cert_expiry_expiring_soon() {
+        use time::{Duration, OffsetDateTime};
+
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        // 10일 후 만료되도록 설정
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - Duration::days(350);
+        params.not_after = now + Duration::days(10);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let der = cert.der().to_vec();
+
+        match check_cert_expiry(&der) {
+            Some(CaExpiryStatus::ExpiringSoon(days)) => {
+                assert!(days >= 9 && days <= 10, "남은 일수: {}", days);
+            }
+            other => panic!("ExpiringSoon이어야 하지만 {:?}", other),
+        }
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_check_cert_expiry_expired() {
+        use time::{Duration, OffsetDateTime};
+
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        // 이미 만료된 인증서
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - Duration::days(400);
+        params.not_after = now - Duration::days(1);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let der = cert.der().to_vec();
+
+        assert!(matches!(
+            check_cert_expiry(&der),
+            Some(CaExpiryStatus::Expired)
+        ));
+    }
+
     #[test]
     fn test_ca_ttl_is_10_years() {
         use super::super::CA_TTL_SECS;
@@ -503,14 +610,117 @@ mod tests {
     }
 
     #[test]
-    fn test_leaf_ttl_is_1_year() {
+    fn test_leaf_ttl_is_90_days() {
         use super::super::LEAF_TTL_SECS;
-        assert_eq!(LEAF_TTL_SECS, 365 * 24 * 60 * 60);
+        assert_eq!(LEAF_TTL_SECS, 90 * 24 * 60 * 60);
     }
 
     #[test]
     fn test_cache_ttl_is_half_leaf() {
         use super::super::{CACHE_TTL, LEAF_TTL_SECS};
         assert_eq!(CACHE_TTL, LEAF_TTL_SECS as u64 / 2);
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_valid() {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let key_pem = key_pair.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        assert!(verify_ca_key_cert_match(&key_pem, &cert_der).is_ok());
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_mismatch() {
+        // 키 A로 만든 인증서에 키 B를 검증하면 실패해야 함
+        let key_a = rcgen::KeyPair::generate().unwrap();
+        let key_b = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_a).unwrap();
+        let key_b_pem = key_b.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        assert!(verify_ca_key_cert_match(&key_b_pem, &cert_der).is_err());
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_invalid_key_pem() {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let cert_der = cert.der().to_vec();
+
+        assert!(verify_ca_key_cert_match("invalid pem", &cert_der).is_err());
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_invalid_cert_der() {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let key_pem = key_pair.serialize_pem();
+
+        assert!(verify_ca_key_cert_match(&key_pem, b"invalid der").is_err());
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_load_or_generate_ca_with_event_returns_event() {
+        let result = load_or_generate_ca_with_event();
+        assert!(result.is_ok());
+        let (_ca, event) = result.unwrap();
+        // 처음 실행이면 CaGenerated 또는 CaLoaded
+        assert!(
+            matches!(
+                event,
+                super::super::CertEvent::CaGenerated
+                    | super::super::CertEvent::CaLoaded
+                    | super::super::CertEvent::CaRegeneratedExpiringSoon(_)
+            ),
+            "예상치 못한 이벤트: {:?}",
+            event
+        );
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_generate_and_save_ca_creates_files() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "cheolsu_ca_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp_dir).unwrap();
+
+        let result = generate_and_save_ca(&tmp_dir);
+        assert!(result.is_ok());
+
+        let key_path = tmp_dir.join("cheolsu-proxy.key");
+        let cer_path = tmp_dir.join("cheolsu-proxy.cer");
+        assert!(key_path.exists(), "키 파일이 생성되어야 함");
+        assert!(cer_path.exists(), "인증서 파일이 생성되어야 함");
+
+        // 생성된 인증서가 Valid인지 확인
+        let cert_der = fs::read(&cer_path).unwrap();
+        assert!(matches!(
+            check_cert_expiry(&cert_der),
+            Some(CaExpiryStatus::Valid)
+        ));
+
+        // 키-인증서 매칭 확인
+        let key_pem = fs::read_to_string(&key_path).unwrap();
+        assert!(verify_ca_key_cert_match(&key_pem, &cert_der).is_ok());
+
+        // cleanup
+        let _ = fs::remove_dir_all(&tmp_dir);
     }
 }

--- a/crates/proxyapi_v2/src/certificate_authority/generator.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/generator.rs
@@ -98,7 +98,6 @@ pub fn load_or_generate_ca_with_event() -> Result<(RcgenAuthority, super::CertEv
 }
 
 /// CA 인증서와 개인키가 매칭되는지 검증하고, 검증된 KeyPair를 반환합니다.
-/// 인증서의 공개키와 개인키로부터 추출한 공개키를 비교합니다.
 #[cfg(feature = "rcgen-ca")]
 fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<rcgen::KeyPair, String> {
     use x509_parser::parse_x509_certificate;
@@ -108,12 +107,14 @@ fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<rcgen::Key
     let (_, cert) =
         parse_x509_certificate(cert_der).map_err(|e| format!("인증서 파싱 실패: {}", e))?;
 
-    let cert_pub_key = cert.public_key().raw;
-    let key_pub_key = key_pair.public_key_raw();
+    // 인증서의 SPKI DER과 개인키의 SPKI DER을 비교
+    let cert_spki = cert.public_key().raw;
+    let key_spki_pem = key_pair.public_key_pem();
+    let key_spki_der = pem::parse(key_spki_pem)
+        .map_err(|e| format!("공개키 PEM 파싱 실패: {}", e))?
+        .into_contents();
 
-    // X.509 SubjectPublicKeyInfo의 끝 부분에 실제 공개키 바이트가 포함됨
-    // rcgen의 public_key_raw()는 raw 바이트만 반환하므로 cert의 SPKI에 포함되어 있는지 확인
-    if !cert_pub_key.ends_with(key_pub_key) {
+    if cert_spki != key_spki_der {
         return Err("CA 인증서와 개인키가 매칭되지 않습니다. 인증서를 재생성합니다.".to_string());
     }
 
@@ -131,7 +132,6 @@ pub fn load_ca_from_storage(
     let cert_der =
         fs::read(cer_path).map_err(|e| format!("Failed to read certificate file: {}", e))?;
 
-    // 키-인증서 매칭 검증 및 KeyPair 재사용
     let key_pair = verify_ca_key_cert_match(&key_pem, &cert_der)?;
 
     let cert_der = CertificateDer::from(cert_der);
@@ -347,15 +347,11 @@ pub fn load_openssl_ca_from_storage(
         "CA 인증서 파일 로드 (PEM 형식)"
     );
 
-    // PEM을 X509로 파싱
     let ca_cert = X509::from_pem(ca_cert_pem.as_bytes())
         .map_err(|e| format!("Failed to parse CA certificate from PEM: {}", e))?;
 
-    // PEM을 PKey로 변환
     let pkey = PKey::private_key_from_pem(private_key_pem.as_bytes())
         .map_err(|e| format!("Failed to parse private key from PEM: {}", e))?;
-
-    // 키-인증서 매칭 검증: 인증서의 공개키와 개인키의 공개키를 비교
     let cert_pub_key_der = ca_cert
         .public_key()
         .map_err(|e| format!("인증서에서 공개키 추출 실패: {}", e))?
@@ -719,5 +715,182 @@ mod tests {
 
         // cleanup
         let _ = fs::remove_dir_all(&tmp_dir);
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_rsa_key() {
+        let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_RSA_SHA256).unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let key_pem = key_pair.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        assert!(
+            verify_ca_key_cert_match(&key_pem, &cert_der).is_ok(),
+            "RSA 키 타입에서도 SPKI 비교가 정확해야 함"
+        );
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_ecdsa_p384_key() {
+        let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let key_pem = key_pair.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        assert!(
+            verify_ca_key_cert_match(&key_pem, &cert_der).is_ok(),
+            "ECDSA P-384 키 타입에서도 SPKI 비교가 정확해야 함"
+        );
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_ed25519_key() {
+        let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let key_pem = key_pair.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        assert!(
+            verify_ca_key_cert_match(&key_pem, &cert_der).is_ok(),
+            "Ed25519 키 타입에서도 SPKI 비교가 정확해야 함"
+        );
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_verify_ca_key_cert_match_returns_usable_keypair() {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let key_pem = key_pair.serialize_pem();
+        let cert_der = cert.der().to_vec();
+
+        // 반환된 KeyPair로 Issuer를 생성할 수 있어야 함
+        let returned_kp = verify_ca_key_cert_match(&key_pem, &cert_der).unwrap();
+        let cert_der_owned = tokio_rustls::rustls::pki_types::CertificateDer::from(cert_der);
+        let issuer = rcgen::Issuer::from_ca_cert_der(&cert_der_owned, returned_kp);
+        assert!(issuer.is_ok(), "반환된 KeyPair로 Issuer 생성이 가능해야 함");
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_generate_and_load_ca_roundtrip() {
+        use super::super::CertificateAuthority;
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "cheolsu_ca_roundtrip_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp_dir).unwrap();
+
+        // 생성
+        let ca1 = generate_and_save_ca(&tmp_dir).unwrap();
+        let ca1_der = ca1.get_ca_cert_der().unwrap();
+
+        // 로드
+        let key_path = tmp_dir.join("cheolsu-proxy.key");
+        let cer_path = tmp_dir.join("cheolsu-proxy.cer");
+        let ca2 = load_ca_from_storage(&key_path, &cer_path).unwrap();
+        let ca2_der = ca2.get_ca_cert_der().unwrap();
+
+        // 동일한 CA 인증서인지 확인
+        assert_eq!(ca1_der, ca2_der, "생성 후 로드한 CA가 동일해야 함");
+
+        let _ = fs::remove_dir_all(&tmp_dir);
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_corrupted_cert_file_triggers_regeneration() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "cheolsu_ca_corrupt_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp_dir).unwrap();
+
+        // 정상 CA 생성
+        generate_and_save_ca(&tmp_dir).unwrap();
+
+        let cer_path = tmp_dir.join("cheolsu-proxy.cer");
+        let key_path = tmp_dir.join("cheolsu-proxy.key");
+
+        // 인증서 파일을 손상시킴
+        fs::write(&cer_path, b"corrupted data").unwrap();
+
+        // 손상된 인증서 로드 시 에러가 발생해야 함
+        let result = load_ca_from_storage(&key_path, &cer_path);
+        assert!(result.is_err(), "손상된 인증서 로드는 실패해야 함");
+
+        let _ = fs::remove_dir_all(&tmp_dir);
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_mismatched_key_cert_triggers_error() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "cheolsu_ca_mismatch_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp_dir).unwrap();
+
+        // CA 생성
+        generate_and_save_ca(&tmp_dir).unwrap();
+
+        // 다른 키로 덮어쓰기
+        let other_key = rcgen::KeyPair::generate().unwrap();
+        let key_path = tmp_dir.join("cheolsu-proxy.key");
+        fs::write(&key_path, other_key.serialize_pem()).unwrap();
+
+        // 키-인증서 불일치로 로드 실패
+        let cer_path = tmp_dir.join("cheolsu-proxy.cer");
+        let result = load_ca_from_storage(&key_path, &cer_path);
+        assert!(result.is_err(), "키-인증서 불일치 시 로드가 실패해야 함");
+
+        let _ = fs::remove_dir_all(&tmp_dir);
+    }
+
+    #[cfg(feature = "rcgen-ca")]
+    #[test]
+    fn test_not_before_offset_applied() {
+        use super::super::NOT_BEFORE_OFFSET;
+        use time::OffsetDateTime;
+
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::default();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - time::Duration::seconds(NOT_BEFORE_OFFSET);
+        params.not_after = now + time::Duration::days(90);
+        let cert = params.self_signed(&key_pair).unwrap();
+        let der = cert.der().to_vec();
+
+        let (_, parsed) = x509_parser::parse_x509_certificate(&der).unwrap();
+        let not_before_ts = parsed.validity().not_before.timestamp();
+        let now_ts = now.unix_timestamp();
+
+        // not_before가 현재 시간보다 NOT_BEFORE_OFFSET(2일) 이전이어야 함
+        assert!(
+            now_ts - not_before_ts >= NOT_BEFORE_OFFSET - 5,
+            "not_before가 약 2일 전이어야 함"
+        );
     }
 }

--- a/crates/proxyapi_v2/src/certificate_authority/generator.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/generator.rs
@@ -97,10 +97,10 @@ pub fn load_or_generate_ca_with_event() -> Result<(RcgenAuthority, super::CertEv
     Ok((ca, super::CertEvent::CaGenerated))
 }
 
-/// CA 인증서와 개인키가 매칭되는지 검증합니다.
+/// CA 인증서와 개인키가 매칭되는지 검증하고, 검증된 KeyPair를 반환합니다.
 /// 인증서의 공개키와 개인키로부터 추출한 공개키를 비교합니다.
 #[cfg(feature = "rcgen-ca")]
-fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<(), String> {
+fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<rcgen::KeyPair, String> {
     use x509_parser::parse_x509_certificate;
 
     let key_pair =
@@ -117,7 +117,7 @@ fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<(), String
         return Err("CA 인증서와 개인키가 매칭되지 않습니다. 인증서를 재생성합니다.".to_string());
     }
 
-    Ok(())
+    Ok(key_pair)
 }
 
 /// 저장된 인증서 파일에서 RcgenAuthority를 로드합니다.
@@ -131,11 +131,8 @@ pub fn load_ca_from_storage(
     let cert_der =
         fs::read(cer_path).map_err(|e| format!("Failed to read certificate file: {}", e))?;
 
-    // 키-인증서 매칭 검증
-    verify_ca_key_cert_match(&key_pem, &cert_der)?;
-
-    let key_pair =
-        rcgen::KeyPair::from_pem(&key_pem).map_err(|e| format!("Failed to parse key: {}", e))?;
+    // 키-인증서 매칭 검증 및 KeyPair 재사용
+    let key_pair = verify_ca_key_cert_match(&key_pem, &cert_der)?;
 
     let cert_der = CertificateDer::from(cert_der);
     let ca_cert_pem = pem::encode(&pem::Pem::new("CERTIFICATE", cert_der.to_vec()));

--- a/crates/proxyapi_v2/src/certificate_authority/generator.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/generator.rs
@@ -107,12 +107,8 @@ fn verify_ca_key_cert_match(key_pem: &str, cert_der: &[u8]) -> Result<rcgen::Key
     let (_, cert) =
         parse_x509_certificate(cert_der).map_err(|e| format!("인증서 파싱 실패: {}", e))?;
 
-    // 인증서의 SPKI DER과 개인키의 SPKI DER을 비교
     let cert_spki = cert.public_key().raw;
-    let key_spki_pem = key_pair.public_key_pem();
-    let key_spki_der = pem::parse(key_spki_pem)
-        .map_err(|e| format!("공개키 PEM 파싱 실패: {}", e))?
-        .into_contents();
+    let key_spki_der = rcgen::PublicKeyData::subject_public_key_info(&key_pair);
 
     if cert_spki != key_spki_der {
         return Err("CA 인증서와 개인키가 매칭되지 않습니다. 인증서를 재생성합니다.".to_string());

--- a/crates/proxyapi_v2/src/certificate_authority/mod.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/mod.rs
@@ -21,11 +21,28 @@ pub use rcgen_authority::*;
 pub use generator::*;
 pub use storage::*;
 
+/// 인증서 관련 이벤트
+#[derive(Debug, Clone, PartialEq)]
+pub enum CertEvent {
+    /// CA 인증서가 새로 생성됨
+    CaGenerated,
+    /// CA 인증서가 만료 임박으로 재생성됨 (남은 일수)
+    CaRegeneratedExpiringSoon(i64),
+    /// CA 인증서가 만료되어 재생성됨
+    CaRegeneratedExpired,
+    /// CA 인증서 로드 실패로 재생성됨 (에러 메시지)
+    CaRegeneratedCorrupted(String),
+    /// CA 인증서가 정상 로드됨
+    CaLoaded,
+}
+
 /// CA 인증서 유효기간 (10년)
 /// mitmproxy와 동일하게 장기간 설정하여 사용자가 자주 재설치하지 않아도 됨
 pub(crate) const CA_TTL_SECS: i64 = 10 * 365 * 24 * 60 * 60;
-/// Leaf 인증서 유효기간 (1년)
-pub(crate) const LEAF_TTL_SECS: i64 = 365 * 24 * 60 * 60;
+/// Leaf 인증서 유효기간 (90일)
+/// Apple/Chrome은 398일 이상 인증서를 거부하고, 업계 트렌드는 90일로 수렴 중.
+/// 짧은 유효기간은 키 노출 시 위험 노출 기간을 줄이고 캐시 갱신 주기를 단축합니다.
+pub(crate) const LEAF_TTL_SECS: i64 = 90 * 24 * 60 * 60;
 pub(crate) const CACHE_TTL: u64 = LEAF_TTL_SECS as u64 / 2;
 /// 인증서 not_before 오프셋 (2일 = 172800초)
 /// 클라이언트 시계 오차를 대비하여 mitmproxy와 동일하게 -2일로 설정

--- a/crates/proxyapi_v2/src/certificate_authority/openssl_authority/openssl_context.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/openssl_authority/openssl_context.rs
@@ -21,14 +21,19 @@ pub(super) async fn gen_openssl_context(
     authority: &Authority,
     upstream_cert: Option<&UpstreamCertInfo>,
 ) -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
-    // 생성자에서 미리 캐시해둔 DER 바이트 사용 (async context에서 OpenSSL 호출 방지)
+    // 캐시 히트 시 불필요한 clone을 피하기 위해 먼저 조회
+    if let Some(ctx) = this.openssl_ctx_cache.get(authority).await {
+        return Ok((*ctx).clone());
+    }
+
+    // 캐시 미스 시에만 데이터 clone (spawn_blocking에 전달할 Send 가능한 형태)
     let ca_cert_der = this.ca_cert_der.clone();
     let pkey_der = this.pkey_der.clone();
     let host = authority.host().to_string();
     let hash = this.hash;
     let upstream_cert = upstream_cert.cloned();
 
-    // Thundering herd 방지: openssl_ctx_cache에 try_get_with 적용
+    // Thundering herd 방지: try_get_with로 동일 authority에 대한 중복 생성 방지
     let ctx = this
         .openssl_ctx_cache
         .try_get_with(authority.clone(), async {

--- a/crates/proxyapi_v2/src/certificate_authority/openssl_authority/openssl_context.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/openssl_authority/openssl_context.rs
@@ -14,24 +14,13 @@ use openssl::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 pub(super) async fn gen_openssl_context(
     this: &OpensslAuthority,
     authority: &Authority,
     upstream_cert: Option<&UpstreamCertInfo>,
 ) -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
-    // 캐시에서 조회
-    if let Some(ctx) = this.openssl_ctx_cache.get(authority).await {
-        debug!("[OPENSSL-CONTEXT] 캐시된 컨텍스트 사용: {}", authority);
-        return Ok((*ctx).clone());
-    }
-
-    info!(
-        "[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 시작: {}",
-        authority
-    );
-
     // 생성자에서 미리 캐시해둔 DER 바이트 사용 (async context에서 OpenSSL 호출 방지)
     let ca_cert_der = this.ca_cert_der.clone();
     let pkey_der = this.pkey_der.clone();
@@ -39,7 +28,27 @@ pub(super) async fn gen_openssl_context(
     let hash = this.hash;
     let upstream_cert = upstream_cert.cloned();
 
-    // 인증서 생성 + OpenSSL 컨텍스트 빌드를 모두 spawn_blocking으로 오프로드
+    // Thundering herd 방지: openssl_ctx_cache에 try_get_with 적용
+    let ctx = this
+        .openssl_ctx_cache
+        .try_get_with(authority.clone(), async {
+            build_openssl_context_inner(ca_cert_der, pkey_der, host, hash, upstream_cert).await
+        })
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?;
+
+    Ok((*ctx).clone())
+}
+
+async fn build_openssl_context_inner(
+    ca_cert_der: Vec<u8>,
+    pkey_der: Vec<u8>,
+    host: String,
+    hash: openssl::hash::MessageDigest,
+    upstream_cert: Option<UpstreamCertInfo>,
+) -> Result<Arc<openssl::ssl::SslContext>, String> {
+    info!("[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 시작: {}", host);
+
     let ctx = tokio::task::spawn_blocking(
         move || -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
             // CA 키 및 인증서 로드
@@ -161,18 +170,10 @@ pub(super) async fn gen_openssl_context(
         },
     )
     .await
-    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-        format!("spawn_blocking failed: {}", e).into()
-    })??;
+    .map_err(|e| format!("spawn_blocking failed: {}", e))?
+    .map_err(|e| e.to_string())?;
 
-    // 캐시에 저장
-    this.openssl_ctx_cache
-        .insert(authority.clone(), Arc::new(ctx.clone()))
-        .await;
+    info!("[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 완료");
 
-    info!(
-        "[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 완료: {}",
-        authority
-    );
-    Ok(ctx)
+    Ok(Arc::new(ctx))
 }

--- a/crates/proxyapi_v2/src/certificate_authority/openssl_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/openssl_authority/trait_impl.rs
@@ -6,16 +6,14 @@ use std::sync::Arc;
 use tokio_rustls::rustls::ServerConfig;
 use tracing::{debug, error, info};
 
-impl CertificateAuthority for OpensslAuthority {
-    async fn gen_server_config(
+impl OpensslAuthority {
+    /// ServerConfig를 빌드하는 내부 메서드.
+    /// Thundering herd 방지를 위해 `gen_server_config`에서 `try_get_with`를 통해 호출됩니다.
+    async fn build_server_config(
         &self,
         authority: &Authority,
         upstream_cert: Option<&UpstreamCertInfo>,
-    ) -> Result<Arc<ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
-        if let Some(server_cfg) = self.cache.get(authority).await {
-            debug!("Using cached server config");
-            return Ok(server_cfg);
-        }
+    ) -> Result<Arc<ServerConfig>, String> {
         debug!("Generating server config");
 
         let (cert, leaf_private_key) = match self.gen_cert(authority, upstream_cert) {
@@ -27,11 +25,10 @@ impl CertificateAuthority for OpensslAuthority {
                 );
                 // 폴백: upstream 정보 없이 재시도
                 self.gen_cert(authority, None).map_err(|e2| {
-                    let msg = format!(
+                    format!(
                         "인증서 생성에 완전히 실패: authority={}, error={:?}",
                         authority, e2
-                    );
-                    Box::<dyn std::error::Error + Send + Sync>::from(msg)
+                    )
                 })?
             }
         };
@@ -44,9 +41,11 @@ impl CertificateAuthority for OpensslAuthority {
         ];
 
         let mut server_cfg = ServerConfig::builder_with_provider(Arc::clone(&self.provider))
-            .with_protocol_versions(&supported_versions)?
+            .with_protocol_versions(&supported_versions)
+            .map_err(|e| e.to_string())?
             .with_no_client_auth()
-            .with_single_cert(certs, leaf_private_key)?;
+            .with_single_cert(certs, leaf_private_key)
+            .map_err(|e| e.to_string())?;
 
         // ALPN 미러링: 상류 서버의 ALPN 협상 결과를 반영
         server_cfg.alpn_protocols = if let Some(ref upstream) = upstream_cert {
@@ -82,13 +81,24 @@ impl CertificateAuthority for OpensslAuthority {
             ]
         };
 
-        let server_cfg = Arc::new(server_cfg);
+        Ok(Arc::new(server_cfg))
+    }
+}
 
+impl CertificateAuthority for OpensslAuthority {
+    async fn gen_server_config(
+        &self,
+        authority: &Authority,
+        upstream_cert: Option<&UpstreamCertInfo>,
+    ) -> Result<Arc<ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
+        // Thundering herd 방지: 동일 authority에 대해 동시 요청이 오면 하나만 생성하고 나머지는 대기
         self.cache
-            .insert(authority.clone(), Arc::clone(&server_cfg))
-            .await;
-
-        Ok(server_cfg)
+            .try_get_with(
+                authority.clone(),
+                self.build_server_config(authority, upstream_cert),
+            )
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })
     }
 
     fn get_ca_cert_der(&self) -> Option<Vec<u8>> {

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/openssl_context.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/openssl_context.rs
@@ -8,31 +8,39 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use time::{Duration, OffsetDateTime};
 use tokio_rustls::rustls::pki_types::CertificateDer;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 pub(super) async fn gen_openssl_context(
     this: &RcgenAuthority,
     authority: &Authority,
     upstream_cert: Option<&UpstreamCertInfo>,
 ) -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
-    // 캐시에서 조회
-    if let Some(ctx) = this.openssl_ctx_cache.get(authority).await {
-        debug!("[OPENSSL-CONTEXT] 캐시된 컨텍스트 사용: {}", authority);
-        return Ok((*ctx).clone());
-    }
-
-    info!(
-        "[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 시작: {}",
-        authority
-    );
-
     // spawn_blocking에 전달할 데이터를 미리 준비 (Send 가능한 형태)
     let ca_cert_pem = this.ca_cert_pem.clone();
     let ca_key_pem = this.ca_key_pem.clone();
     let host = authority.host().to_string();
     let upstream_cert = upstream_cert.cloned();
 
-    // 인증서 생성 + OpenSSL 컨텍스트 빌드를 모두 spawn_blocking으로 오프로드
+    // Thundering herd 방지: openssl_ctx_cache에 try_get_with 적용
+    let ctx = this
+        .openssl_ctx_cache
+        .try_get_with(authority.clone(), async {
+            build_openssl_context(ca_cert_pem, ca_key_pem, host, upstream_cert).await
+        })
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?;
+
+    Ok((*ctx).clone())
+}
+
+async fn build_openssl_context(
+    ca_cert_pem: String,
+    ca_key_pem: String,
+    host: String,
+    upstream_cert: Option<UpstreamCertInfo>,
+) -> Result<Arc<openssl::ssl::SslContext>, String> {
+    info!("[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 시작: {}", host);
+
     let ctx = tokio::task::spawn_blocking(
         move || -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
             // rcgen 인증서 생성 (CPU 집약적 작업)
@@ -152,18 +160,10 @@ pub(super) async fn gen_openssl_context(
         },
     )
     .await
-    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-        format!("spawn_blocking failed: {}", e).into()
-    })??;
+    .map_err(|e| format!("spawn_blocking failed: {}", e))?
+    .map_err(|e| e.to_string())?;
 
-    // 캐시에 저장
-    this.openssl_ctx_cache
-        .insert(authority.clone(), Arc::new(ctx.clone()))
-        .await;
+    info!("[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 완료");
 
-    info!(
-        "[OPENSSL-CONTEXT] OpenSSL 컨텍스트 생성 완료: {}",
-        authority
-    );
-    Ok(ctx)
+    Ok(Arc::new(ctx))
 }

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/openssl_context.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/openssl_context.rs
@@ -15,13 +15,18 @@ pub(super) async fn gen_openssl_context(
     authority: &Authority,
     upstream_cert: Option<&UpstreamCertInfo>,
 ) -> Result<openssl::ssl::SslContext, Box<dyn std::error::Error + Send + Sync>> {
-    // spawn_blocking에 전달할 데이터를 미리 준비 (Send 가능한 형태)
+    // 캐시 히트 시 불필요한 clone을 피하기 위해 먼저 조회
+    if let Some(ctx) = this.openssl_ctx_cache.get(authority).await {
+        return Ok((*ctx).clone());
+    }
+
+    // 캐시 미스 시에만 데이터 clone (spawn_blocking에 전달할 Send 가능한 형태)
     let ca_cert_pem = this.ca_cert_pem.clone();
     let ca_key_pem = this.ca_key_pem.clone();
     let host = authority.host().to_string();
     let upstream_cert = upstream_cert.cloned();
 
-    // Thundering herd 방지: openssl_ctx_cache에 try_get_with 적용
+    // Thundering herd 방지: try_get_with로 동일 authority에 대한 중복 생성 방지
     let ctx = this
         .openssl_ctx_cache
         .try_get_with(authority.clone(), async {

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
@@ -1,11 +1,9 @@
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "openssl-ca")]
     use crate::certificate_authority::CertificateAuthority;
     use crate::certificate_authority::rcgen_authority::RcgenAuthority;
     use crate::upstream_cert::UpstreamCertInfo;
     use http::uri::Authority;
-    #[cfg(feature = "openssl-ca")]
     use std::sync::Arc;
     use tokio_rustls::rustls::crypto::aws_lc_rs;
 
@@ -327,5 +325,100 @@ mod tests {
             .and_then(|attr| attr.as_str().ok())
             .unwrap();
         assert!(cn.len() <= 64, "CN이 64자를 초과합니다: {} chars", cn.len());
+    }
+
+    /// Thundering herd 방지 테스트: 동일 도메인에 동시 요청 시 인증서가 한 번만 생성되는지 확인
+    #[tokio::test]
+    async fn gen_server_config_thundering_herd() {
+        let ca = Arc::new(build_ca(1_000));
+        let authority = Authority::from_static("thundering-herd.example.com");
+
+        // 10개 동시 요청 발행
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let ca_clone = ca.clone();
+            let auth_clone = authority.clone();
+            handles.push(tokio::spawn(async move {
+                ca_clone
+                    .gen_server_config(&auth_clone, None)
+                    .await
+                    .expect("ServerConfig 생성 실패")
+            }));
+        }
+
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // 모든 결과가 동일한 Arc를 공유해야 함 (동일 캐시 엔트리)
+        // Arc::ptr_eq로 같은 인스턴스인지 확인
+        let first = &results[0];
+        for (i, result) in results.iter().enumerate().skip(1) {
+            assert!(
+                Arc::ptr_eq(first, result),
+                "요청 {}이 다른 ServerConfig 인스턴스를 반환했습니다 (thundering herd 발생)",
+                i
+            );
+        }
+    }
+
+    /// 캐시 히트 시 동일한 ServerConfig가 반환되는지 확인
+    #[tokio::test]
+    async fn gen_server_config_cache_returns_same_instance() {
+        let ca = build_ca(1_000);
+        let authority = Authority::from_static("cache-instance.example.com");
+
+        let cfg1 = ca.gen_server_config(&authority, None).await.unwrap();
+        let cfg2 = ca.gen_server_config(&authority, None).await.unwrap();
+
+        assert!(
+            Arc::ptr_eq(&cfg1, &cfg2),
+            "캐시에서 반환된 ServerConfig는 동일 인스턴스여야 합니다"
+        );
+    }
+
+    /// Leaf 인증서 유효기간이 90일인지 확인
+    #[test]
+    fn gen_cert_leaf_validity_is_90_days() {
+        let ca = build_ca(0);
+        let authority = Authority::from_static("leaf-ttl.example.com");
+
+        let cert_der = ca.gen_cert(&authority, None).unwrap().0;
+        let (_, cert) = x509_parser::parse_x509_certificate(&cert_der).unwrap();
+
+        let not_before = cert.validity().not_before.timestamp();
+        let not_after = cert.validity().not_after.timestamp();
+        let validity_secs = not_after - not_before;
+
+        // 90일 = 7,776,000초 (NOT_BEFORE_OFFSET 포함 보정)
+        let expected = crate::certificate_authority::LEAF_TTL_SECS;
+        assert_eq!(
+            validity_secs, expected,
+            "Leaf 인증서 유효기간이 {}초(90일)여야 하지만 {}초입니다",
+            expected, validity_secs
+        );
+    }
+
+    /// CertEvent enum이 올바르게 동작하는지 확인
+    #[test]
+    fn cert_event_variants() {
+        use crate::certificate_authority::CertEvent;
+
+        let e1 = CertEvent::CaGenerated;
+        let e2 = CertEvent::CaRegeneratedExpiringSoon(15);
+        let e3 = CertEvent::CaRegeneratedExpired;
+        let e4 = CertEvent::CaRegeneratedCorrupted("키 불일치".to_string());
+        let e5 = CertEvent::CaLoaded;
+
+        // Debug, Clone, PartialEq 동작 확인
+        assert_eq!(e1.clone(), CertEvent::CaGenerated);
+        assert_eq!(e2.clone(), CertEvent::CaRegeneratedExpiringSoon(15));
+        assert_ne!(e3, e5);
+        assert_eq!(
+            format!("{:?}", e4),
+            r#"CaRegeneratedCorrupted("키 불일치")"#
+        );
     }
 }

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
@@ -6,17 +6,14 @@ use std::sync::Arc;
 use tokio_rustls::rustls::ServerConfig;
 use tracing::{debug, error, info, warn};
 
-impl CertificateAuthority for RcgenAuthority {
-    async fn gen_server_config(
+impl RcgenAuthority {
+    /// ServerConfig를 빌드하는 내부 메서드.
+    /// Thundering herd 방지를 위해 `gen_server_config`에서 `try_get_with`를 통해 호출됩니다.
+    async fn build_server_config(
         &self,
         authority: &Authority,
         upstream_cert: Option<&UpstreamCertInfo>,
-    ) -> Result<Arc<ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
-        if let Some(server_cfg) = self.cache.get(authority).await {
-            debug!("Using cached server config for {}", authority);
-            return Ok(server_cfg);
-        }
-
+    ) -> Result<Arc<ServerConfig>, String> {
         info!("[SERVER-CONFIG] 서버 설정 생성 시작: {}", authority);
         let start_time = std::time::Instant::now();
 
@@ -30,11 +27,10 @@ impl CertificateAuthority for RcgenAuthority {
                 );
                 // 폴백: upstream 정보 없이 재시도
                 self.gen_cert(authority, None).map_err(|e2| {
-                    let msg = format!(
+                    format!(
                         "인증서 생성에 완전히 실패: authority={}, error={:?}",
                         authority, e2
-                    );
-                    Box::<dyn std::error::Error + Send + Sync>::from(msg)
+                    )
                 })?
             }
         };
@@ -61,16 +57,18 @@ impl CertificateAuthority for RcgenAuthority {
                         .allow_unauthenticated()
                         .build()
                         .map_err(|e| {
-                            Box::<dyn std::error::Error + Send + Sync>::from(format!(
+                            format!(
                                 "Failed to build WebPkiClientVerifier (allow_unauthenticated): {e}"
-                            ))
+                            )
                         })?;
 
                         info!("[SERVER-CONFIG] 클라이언트 인증서 선택적 요청 (required=false)");
                         ServerConfig::builder_with_provider(Arc::clone(&self.provider))
-                            .with_protocol_versions(&supported_versions)?
+                            .with_protocol_versions(&supported_versions)
+                            .map_err(|e| e.to_string())?
                             .with_client_cert_verifier(verifier)
-                            .with_single_cert(certs, leaf_private_key.clone_key())?
+                            .with_single_cert(certs, leaf_private_key.clone_key())
+                            .map_err(|e| e.to_string())?
                     } else {
                         // CA 기반 검증 (필수)
                         let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
@@ -84,9 +82,7 @@ impl CertificateAuthority for RcgenAuthority {
                         )
                         .build()
                         .map_err(|e| {
-                            Box::<dyn std::error::Error + Send + Sync>::from(format!(
-                                "Failed to build WebPkiClientVerifier (required): {e}"
-                            ))
+                            format!("Failed to build WebPkiClientVerifier (required): {e}")
                         })?;
 
                         info!(
@@ -94,23 +90,29 @@ impl CertificateAuthority for RcgenAuthority {
                             verify_config.ca_certs.len()
                         );
                         ServerConfig::builder_with_provider(Arc::clone(&self.provider))
-                            .with_protocol_versions(&supported_versions)?
+                            .with_protocol_versions(&supported_versions)
+                            .map_err(|e| e.to_string())?
                             .with_client_cert_verifier(verifier)
-                            .with_single_cert(certs, leaf_private_key.clone_key())?
+                            .with_single_cert(certs, leaf_private_key.clone_key())
+                            .map_err(|e| e.to_string())?
                     }
                 } else {
                     // 비활성화 - 기존 동작
                     ServerConfig::builder_with_provider(Arc::clone(&self.provider))
-                        .with_protocol_versions(&supported_versions)?
+                        .with_protocol_versions(&supported_versions)
+                        .map_err(|e| e.to_string())?
                         .with_no_client_auth()
-                        .with_single_cert(certs, leaf_private_key.clone_key())?
+                        .with_single_cert(certs, leaf_private_key.clone_key())
+                        .map_err(|e| e.to_string())?
                 }
             } else {
                 // 설정 없음 - 기존 동작
                 ServerConfig::builder_with_provider(Arc::clone(&self.provider))
-                    .with_protocol_versions(&supported_versions)?
+                    .with_protocol_versions(&supported_versions)
+                    .map_err(|e| e.to_string())?
                     .with_no_client_auth()
-                    .with_single_cert(certs, leaf_private_key.clone_key())?
+                    .with_single_cert(certs, leaf_private_key.clone_key())
+                    .map_err(|e| e.to_string())?
             }
         };
 
@@ -167,11 +169,24 @@ impl CertificateAuthority for RcgenAuthority {
             authority, duration
         );
 
-        self.cache
-            .insert(authority.clone(), Arc::clone(&server_cfg))
-            .await;
-
         Ok(server_cfg)
+    }
+}
+
+impl CertificateAuthority for RcgenAuthority {
+    async fn gen_server_config(
+        &self,
+        authority: &Authority,
+        upstream_cert: Option<&UpstreamCertInfo>,
+    ) -> Result<Arc<ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
+        // Thundering herd 방지: 동일 authority에 대해 동시 요청이 오면 하나만 생성하고 나머지는 대기
+        self.cache
+            .try_get_with(
+                authority.clone(),
+                self.build_server_config(authority, upstream_cert),
+            )
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })
     }
 
     fn get_ca_cert_der(&self) -> Option<Vec<u8>> {


### PR DESCRIPTION
## 개요

인증서 시스템의 안정성을 전반적으로 개선합니다. 동시 요청 시 중복 인증서 생성 방지, CA 만료 시 자동 재생성, 키-인증서 매칭 검증, Leaf 인증서 유효기간 단축, 이벤트 알림 시스템을 추가합니다.

## 변경 내용

### 수정된 파일

- `certificate_authority/mod.rs` — `LEAF_TTL_SECS` 365일→90일 변경, `CertEvent` enum 추가
- `certificate_authority/generator.rs` — CA 자동 재생성, `verify_ca_key_cert_match()` 추가 (SPKI DER 전체 비교), `load_or_generate_ca_with_event()` API 추가, OpenSSL 키-인증서 검증 추가, 테스트 20건 추가
- `rcgen_authority/trait_impl.rs` — `build_server_config()` 메서드 분리, `try_get_with`로 thundering herd 방지
- `openssl_authority/trait_impl.rs` — 동일 패턴 적용
- `rcgen_authority/openssl_context.rs` — `build_openssl_context()` 분리, `try_get_with` 적용, 캐시 히트 시 불필요한 String clone 방지
- `openssl_authority/openssl_context.rs` — 동일 패턴 적용
- `rcgen_authority/tests.rs` — thundering herd, 캐시 히트, leaf 유효기간, CertEvent 테스트 추가

## 구현 상세

### 1. Thundering Herd 방지 (`try_get_with`)

브라우저가 한 페이지 로드 시 같은 도메인에 6~10개 동시 연결을 여는데, 캐시가 비어있을 때 인증서가 중복 생성되는 문제를 해결합니다.

```
기존: 요청 A → cache.get() 미스 → 인증서 생성 시작
      요청 B → cache.get() 미스 → 인증서 생성 시작 (중복!)

개선: 요청 A → cache.try_get_with() → 인증서 생성 시작 (리더)
      요청 B → cache.try_get_with() → 요청 A 대기... → A 결과 공유
```

- rcgen/openssl ServerConfig 캐시, OpenSSL context 캐시 모두 적용
- openssl_context에서는 `cache.get()` fast path를 추가하여 캐시 히트 시 불필요한 String clone 방지

### 2. CA 만료 임박 시 자동 재생성

- `ExpiringSoon` (30일 미만) 상태에서 경고만 하던 것을 **자동 재생성**으로 변경
- rcgen, OpenSSL 양쪽 모두 적용

### 3. CA 로드 시 키-인증서 매칭 검증

- rcgen: `verify_ca_key_cert_match()` — SPKI DER 전체 비교 (초기 리뷰의 `ends_with` 비교에서 강화)
  - `key_pair.public_key_pem()`으로 SPKI를 추출하여 인증서의 SPKI와 정확히 일치하는지 확인
  - 검증 성공 시 `KeyPair`를 반환하여 이후 중복 파싱 방지
- OpenSSL: `public_key_to_der()` 비교
- 검증 실패 시 자동 재생성 (손상된 인증서 자동 복구)

### 4. Leaf 인증서 유효기간 90일로 단축

- `LEAF_TTL_SECS`: 365일 → 90일 (Apple/Chrome 트렌드 반영)
- `CACHE_TTL`: 자동으로 45일로 조정

### 5. 인증서 이벤트 알림 시스템

- `CertEvent` enum: `CaGenerated`, `CaRegeneratedExpiringSoon(i64)`, `CaRegeneratedExpired`, `CaRegeneratedCorrupted(String)`, `CaLoaded`
- `load_or_generate_ca_with_event()` — 이벤트와 함께 CA 반환
- 기존 `load_or_generate_ca()`는 하위 호환성 유지

## 코드 리뷰 반영 사항

- `verify_ca_key_cert_match`가 검증된 `KeyPair`를 반환하도록 변경 (중복 파싱 제거)
- `openssl_context.rs`에서 `cache.get()` fast path 추가 (캐시 히트 시 String clone 방지)
- `ends_with` SPKI 비교 → 전체 SPKI DER 비교로 강화 (모든 키 타입에서 정확)
- 불필요한 WHAT 주석 제거

## 테스트

총 65개 테스트 통과 (기존 49개 + 신규 16개):

### Thundering Herd / 캐시
- [x] `gen_server_config_thundering_herd` — 10개 동시 요청 시 동일 Arc 인스턴스 반환
- [x] `gen_server_config_cache_returns_same_instance` — 캐시 히트 시 동일 인스턴스

### Leaf 인증서
- [x] `gen_cert_leaf_validity_is_90_days` — 유효기간 90일 검증
- [x] `test_not_before_offset_applied` — NOT_BEFORE_OFFSET 2일 적용 확인

### CA 만료 감지
- [x] `test_check_cert_expiry_expiring_soon` — 만료 임박 인증서 감지
- [x] `test_check_cert_expiry_expired` — 만료된 인증서 감지

### 키-인증서 매칭 (SPKI DER 비교)
- [x] `test_verify_ca_key_cert_match_valid` — 정상 매칭 (ECDSA P-256)
- [x] `test_verify_ca_key_cert_match_rsa_key` — RSA 키 타입 SPKI 비교
- [x] `test_verify_ca_key_cert_match_ecdsa_p384_key` — ECDSA P-384 SPKI 비교
- [x] `test_verify_ca_key_cert_match_ed25519_key` — Ed25519 SPKI 비교
- [x] `test_verify_ca_key_cert_match_mismatch` — 키 불일치 감지
- [x] `test_verify_ca_key_cert_match_invalid_key_pem` — 잘못된 키 PEM 감지
- [x] `test_verify_ca_key_cert_match_invalid_cert_der` — 잘못된 인증서 DER 감지
- [x] `test_verify_ca_key_cert_match_returns_usable_keypair` — 반환된 KeyPair 사용 가능성

### CA 생성/로드/복구
- [x] `test_generate_and_save_ca_creates_files` — CA 파일 생성 및 유효성
- [x] `test_generate_and_load_ca_roundtrip` — 생성→로드 왕복 일관성
- [x] `test_corrupted_cert_file_triggers_regeneration` — 손상된 인증서 감지
- [x] `test_mismatched_key_cert_triggers_error` — 키-인증서 불일치 감지
- [x] `test_load_or_generate_ca_with_event_returns_event` — CertEvent 반환 확인

### 이벤트 시스템
- [x] `cert_event_variants` — CertEvent enum Debug/Clone/PartialEq 동작