### PR TITLE
feat(proxyapi_v2): 인증서 최적화 — 메트릭, 타임아웃, ALPN 공통화, 와일드카드 캐시

### DIFF
--- a/crates/proxyapi_v2/src/certificate_authority/mod.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/mod.rs
@@ -160,16 +160,13 @@ pub(crate) fn wildcard_authority(authority: &Authority) -> Option<Authority> {
         return Some(authority.clone());
     }
 
-    // 최소 2개 도트가 있어야 와일드카드 가능 (example.com → 불가, sub.example.com → 가능)
+    // sub.example.com → *.example.com (최소 서브도메인이 있어야 함)
     let dot_pos = host.find('.')?;
     let root = &host[dot_pos..]; // .example.com
 
-    // TLD만 남으면 안 됨 (예: .com)
-    if root.matches('.').count() < 2 {
-        // root가 .example.com 형태인지 확인 (최소 1개 도트 더 필요)
-        if !root[1..].contains('.') {
-            return None;
-        }
+    // root에 추가 도트가 없으면 TLD만 남은 것 (예: .com → 불가)
+    if !root[1..].contains('.') {
+        return None;
     }
 
     let wildcard_host = format!("*{}", root);

--- a/crates/proxyapi_v2/src/certificate_authority/mod.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/mod.rs
@@ -47,6 +47,169 @@ pub(crate) const CACHE_TTL: u64 = LEAF_TTL_SECS as u64 / 2;
 /// 인증서 not_before 오프셋 (2일 = 172800초)
 /// 클라이언트 시계 오차를 대비하여 mitmproxy와 동일하게 -2일로 설정
 pub(crate) const NOT_BEFORE_OFFSET: i64 = 172_800;
+/// 인증서 생성 타임아웃 (초)
+/// RSA 키 생성이 시스템 부하로 비정상적으로 오래 걸릴 때를 대비
+pub(crate) const CERT_GEN_TIMEOUT_SECS: u64 = 10;
+
+/// 인증서 생성 메트릭 수집기
+///
+/// Atomic 카운터 기반으로 lock-free하게 인증서 생성 통계를 수집합니다.
+#[derive(Debug)]
+pub struct CertMetrics {
+    /// 인증서 생성 횟수
+    pub gen_count: std::sync::atomic::AtomicU64,
+    /// 캐시 히트 횟수
+    pub cache_hit_count: std::sync::atomic::AtomicU64,
+    /// 인증서 생성 실패 횟수
+    pub gen_failure_count: std::sync::atomic::AtomicU64,
+    /// 인증서 생성 총 소요시간 (마이크로초)
+    pub total_gen_duration_us: std::sync::atomic::AtomicU64,
+}
+
+impl CertMetrics {
+    pub fn new() -> Self {
+        use std::sync::atomic::AtomicU64;
+        Self {
+            gen_count: AtomicU64::new(0),
+            cache_hit_count: AtomicU64::new(0),
+            gen_failure_count: AtomicU64::new(0),
+            total_gen_duration_us: AtomicU64::new(0),
+        }
+    }
+
+    pub fn record_gen(&self, duration: std::time::Duration) {
+        use std::sync::atomic::Ordering::Relaxed;
+        self.gen_count.fetch_add(1, Relaxed);
+        self.total_gen_duration_us
+            .fetch_add(duration.as_micros() as u64, Relaxed);
+    }
+
+    pub fn record_cache_hit(&self) {
+        self.cache_hit_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn record_failure(&self) {
+        self.gen_failure_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// 평균 생성 시간 (마이크로초). 생성 횟수가 0이면 0 반환.
+    pub fn avg_gen_duration_us(&self) -> u64 {
+        use std::sync::atomic::Ordering::Relaxed;
+        let count = self.gen_count.load(Relaxed);
+        if count == 0 {
+            return 0;
+        }
+        self.total_gen_duration_us.load(Relaxed) / count
+    }
+
+    /// 캐시 히트율 (0.0~1.0). 요청이 없으면 0.0 반환.
+    pub fn cache_hit_rate(&self) -> f64 {
+        use std::sync::atomic::Ordering::Relaxed;
+        let hits = self.cache_hit_count.load(Relaxed);
+        let gens = self.gen_count.load(Relaxed);
+        let total = hits + gens;
+        if total == 0 {
+            return 0.0;
+        }
+        hits as f64 / total as f64
+    }
+
+    pub fn snapshot(&self) -> CertMetricsSnapshot {
+        use std::sync::atomic::Ordering::Relaxed;
+        CertMetricsSnapshot {
+            gen_count: self.gen_count.load(Relaxed),
+            cache_hit_count: self.cache_hit_count.load(Relaxed),
+            gen_failure_count: self.gen_failure_count.load(Relaxed),
+            avg_gen_duration_us: self.avg_gen_duration_us(),
+            cache_hit_rate: self.cache_hit_rate(),
+        }
+    }
+}
+
+impl Default for CertMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 메트릭 스냅샷 (직렬화/로깅용)
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CertMetricsSnapshot {
+    pub gen_count: u64,
+    pub cache_hit_count: u64,
+    pub gen_failure_count: u64,
+    pub avg_gen_duration_us: u64,
+    pub cache_hit_rate: f64,
+}
+
+/// 호스트에서 와일드카드 Authority를 추출합니다.
+/// `api.example.com:443` → `*.example.com:443`
+/// IP 주소나 TLD는 None을 반환합니다.
+pub(crate) fn wildcard_authority(authority: &Authority) -> Option<Authority> {
+    let host = authority.host();
+
+    // IP 주소는 와일드카드 불가
+    if host.parse::<std::net::IpAddr>().is_ok() {
+        return None;
+    }
+
+    // 이미 와일드카드이면 그대로
+    if host.starts_with("*.") {
+        return Some(authority.clone());
+    }
+
+    // 최소 2개 도트가 있어야 와일드카드 가능 (example.com → 불가, sub.example.com → 가능)
+    let dot_pos = host.find('.')?;
+    let root = &host[dot_pos..]; // .example.com
+
+    // TLD만 남으면 안 됨 (예: .com)
+    if root.matches('.').count() < 2 {
+        // root가 .example.com 형태인지 확인 (최소 1개 도트 더 필요)
+        if !root[1..].contains('.') {
+            return None;
+        }
+    }
+
+    let wildcard_host = format!("*{}", root);
+    let wildcard_str = if let Some(port) = authority.port() {
+        format!("{}:{}", wildcard_host, port)
+    } else {
+        wildcard_host
+    };
+
+    Authority::try_from(wildcard_str).ok()
+}
+
+/// upstream 서버의 ALPN 협상 결과를 기반으로 ALPN 프로토콜 리스트를 구성합니다.
+/// 협상된 프로토콜을 우선 배치하고, 나머지 지원 프로토콜을 폴백으로 추가합니다.
+pub(crate) fn build_alpn_protocols(upstream_cert: Option<&UpstreamCertInfo>) -> Vec<Vec<u8>> {
+    let default_protocols = || {
+        vec![
+            #[cfg(feature = "http2")]
+            b"h2".to_vec(),
+            b"http/1.1".to_vec(),
+        ]
+    };
+
+    let Some(upstream) = upstream_cert else {
+        return default_protocols();
+    };
+    let Some(ref negotiated) = upstream.negotiated_alpn else {
+        return default_protocols();
+    };
+
+    let mut protocols = vec![negotiated.clone()];
+    #[cfg(feature = "http2")]
+    if negotiated != b"h2" {
+        protocols.push(b"h2".to_vec());
+    }
+    if negotiated != b"http/1.1" {
+        protocols.push(b"http/1.1".to_vec());
+    }
+    protocols
+}
 
 /// 128비트 난수 시리얼 번호를 생성합니다.
 /// RFC 5280: serial number는 양수 INTEGER이므로 최상위 비트를 클리어합니다.
@@ -97,17 +260,169 @@ mod tests {
 
     #[test]
     fn truncate_cn_multibyte_under_limit() {
-        // 한글 20자 = 60바이트이지만 문자 수는 20
         let cn: String = "가".repeat(20);
         assert_eq!(truncate_cn(&cn), cn);
     }
 
     #[test]
     fn truncate_cn_multibyte_over_limit() {
-        // 한글 70자 → 64자로 truncate
         let cn: String = "가".repeat(70);
         let result = truncate_cn(&cn);
         assert_eq!(result.chars().count(), 64);
+    }
+
+    // --- wildcard_authority 테스트 ---
+
+    use super::wildcard_authority;
+    use http::uri::Authority;
+
+    #[test]
+    fn wildcard_subdomain() {
+        let auth = Authority::from_static("api.example.com");
+        let wc = wildcard_authority(&auth).unwrap();
+        assert_eq!(wc.host(), "*.example.com");
+    }
+
+    #[test]
+    fn wildcard_deep_subdomain() {
+        let auth = Authority::from_static("a.b.example.com");
+        let wc = wildcard_authority(&auth).unwrap();
+        assert_eq!(wc.host(), "*.b.example.com");
+    }
+
+    #[test]
+    fn wildcard_preserves_port() {
+        let auth = Authority::from_static("api.example.com:8443");
+        let wc = wildcard_authority(&auth).unwrap();
+        assert_eq!(wc.to_string(), "*.example.com:8443");
+    }
+
+    #[test]
+    fn wildcard_root_domain_returns_none() {
+        let auth = Authority::from_static("example.com");
+        assert!(wildcard_authority(&auth).is_none());
+    }
+
+    #[test]
+    fn wildcard_ip_returns_none() {
+        let auth = Authority::from_static("192.168.1.1:443");
+        assert!(wildcard_authority(&auth).is_none());
+    }
+
+    #[test]
+    fn wildcard_already_wildcard() {
+        let auth = Authority::from_static("*.example.com");
+        let wc = wildcard_authority(&auth).unwrap();
+        assert_eq!(wc.host(), "*.example.com");
+    }
+
+    #[test]
+    fn wildcard_localhost_returns_none() {
+        let auth = Authority::from_static("localhost");
+        assert!(wildcard_authority(&auth).is_none());
+    }
+
+    // --- build_alpn_protocols 테스트 ---
+
+    use super::build_alpn_protocols;
+    use crate::upstream_cert::UpstreamCertInfo;
+
+    #[test]
+    fn alpn_no_upstream() {
+        let protocols = build_alpn_protocols(None);
+        assert!(protocols.contains(&b"http/1.1".to_vec()));
+    }
+
+    #[test]
+    fn alpn_with_negotiated_h2() {
+        let upstream = UpstreamCertInfo {
+            negotiated_alpn: Some(b"h2".to_vec()),
+            ..Default::default()
+        };
+        let protocols = build_alpn_protocols(Some(&upstream));
+        assert_eq!(protocols[0], b"h2");
+        assert!(protocols.contains(&b"http/1.1".to_vec()));
+    }
+
+    #[test]
+    fn alpn_with_negotiated_http11() {
+        let upstream = UpstreamCertInfo {
+            negotiated_alpn: Some(b"http/1.1".to_vec()),
+            ..Default::default()
+        };
+        let protocols = build_alpn_protocols(Some(&upstream));
+        assert_eq!(protocols[0], b"http/1.1");
+        // http/1.1이 이미 있으므로 중복 추가 안 됨
+        assert_eq!(
+            protocols
+                .iter()
+                .filter(|p| *p == &b"http/1.1".to_vec())
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn alpn_no_negotiated() {
+        let upstream = UpstreamCertInfo {
+            negotiated_alpn: None,
+            ..Default::default()
+        };
+        let protocols = build_alpn_protocols(Some(&upstream));
+        assert!(protocols.contains(&b"http/1.1".to_vec()));
+    }
+
+    // --- CertMetrics 테스트 ---
+
+    use super::CertMetrics;
+
+    #[test]
+    fn metrics_initial_state() {
+        let m = CertMetrics::new();
+        assert_eq!(m.avg_gen_duration_us(), 0);
+        assert_eq!(m.cache_hit_rate(), 0.0);
+        let snap = m.snapshot();
+        assert_eq!(snap.gen_count, 0);
+        assert_eq!(snap.cache_hit_count, 0);
+        assert_eq!(snap.gen_failure_count, 0);
+    }
+
+    #[test]
+    fn metrics_record_gen() {
+        let m = CertMetrics::new();
+        m.record_gen(std::time::Duration::from_millis(100));
+        m.record_gen(std::time::Duration::from_millis(200));
+        let snap = m.snapshot();
+        assert_eq!(snap.gen_count, 2);
+        assert!(snap.avg_gen_duration_us >= 100_000); // 최소 100ms
+    }
+
+    #[test]
+    fn metrics_cache_hit_rate() {
+        let m = CertMetrics::new();
+        m.record_cache_hit();
+        m.record_cache_hit();
+        m.record_cache_hit();
+        m.record_gen(std::time::Duration::from_millis(1));
+        // 3 hits / (3 hits + 1 gen) = 0.75
+        assert!((m.cache_hit_rate() - 0.75).abs() < 0.01);
+    }
+
+    #[test]
+    fn metrics_record_failure() {
+        let m = CertMetrics::new();
+        m.record_failure();
+        m.record_failure();
+        assert_eq!(m.snapshot().gen_failure_count, 2);
+    }
+
+    #[test]
+    fn metrics_snapshot_serializable() {
+        let m = CertMetrics::new();
+        m.record_gen(std::time::Duration::from_millis(50));
+        let snap = m.snapshot();
+        let json = serde_json::to_string(&snap);
+        assert!(json.is_ok(), "CertMetricsSnapshot은 직렬화 가능해야 함");
     }
 }
 

--- a/crates/proxyapi_v2/src/certificate_authority/openssl_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/openssl_authority/trait_impl.rs
@@ -4,7 +4,7 @@ use crate::upstream_cert::UpstreamCertInfo;
 use http::uri::Authority;
 use std::sync::Arc;
 use tokio_rustls::rustls::ServerConfig;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 impl OpensslAuthority {
     /// ServerConfig를 빌드하는 내부 메서드.
@@ -47,39 +47,8 @@ impl OpensslAuthority {
             .with_single_cert(certs, leaf_private_key)
             .map_err(|e| e.to_string())?;
 
-        // ALPN 미러링: 상류 서버의 ALPN 협상 결과를 반영
-        server_cfg.alpn_protocols = if let Some(ref upstream) = upstream_cert {
-            if let Some(ref negotiated) = upstream.negotiated_alpn {
-                let mut protocols = vec![negotiated.clone()];
-                #[cfg(feature = "http2")]
-                if negotiated != b"h2" {
-                    protocols.push(b"h2".to_vec());
-                }
-                if negotiated != b"http/1.1" {
-                    protocols.push(b"http/1.1".to_vec());
-                }
-                info!(
-                    "[SERVER-CONFIG] ALPN 미러링 적용: {:?}",
-                    protocols
-                        .iter()
-                        .map(|p| String::from_utf8_lossy(p).to_string())
-                        .collect::<Vec<_>>()
-                );
-                protocols
-            } else {
-                vec![
-                    #[cfg(feature = "http2")]
-                    b"h2".to_vec(),
-                    b"http/1.1".to_vec(),
-                ]
-            }
-        } else {
-            vec![
-                #[cfg(feature = "http2")]
-                b"h2".to_vec(),
-                b"http/1.1".to_vec(),
-            ]
-        };
+        server_cfg.alpn_protocols =
+            crate::certificate_authority::build_alpn_protocols(upstream_cert);
 
         Ok(Arc::new(server_cfg))
     }

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/mod.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/mod.rs
@@ -54,6 +54,8 @@ pub struct RcgenAuthority {
     pub(super) provider: Arc<CryptoProvider>,
     /// 클라이언트 인증서 요청 설정
     pub(super) client_cert_verify: Arc<tokio::sync::RwLock<Option<ClientCertVerifyConfig>>>,
+    /// 인증서 생성 메트릭
+    pub(super) metrics: Arc<crate::certificate_authority::CertMetrics>,
 }
 
 impl RcgenAuthority {
@@ -82,7 +84,13 @@ impl RcgenAuthority {
                 .build(),
             provider: Arc::new(provider),
             client_cert_verify: Arc::new(tokio::sync::RwLock::new(None)),
+            metrics: Arc::new(crate::certificate_authority::CertMetrics::new()),
         }
+    }
+
+    /// 인증서 메트릭 핸들을 반환합니다.
+    pub fn get_metrics(&self) -> Arc<crate::certificate_authority::CertMetrics> {
+        Arc::clone(&self.metrics)
     }
 
     /// PEM 문자열에서 RcgenAuthority를 생성하는 편의 생성자.

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
@@ -401,6 +401,63 @@ mod tests {
         );
     }
 
+    /// 와일드카드 캐시 공유 테스트: 같은 루트 도메인의 서브도메인이 캐시를 공유하는지 확인
+    #[tokio::test]
+    async fn wildcard_cache_sharing() {
+        let ca = Arc::new(build_ca(1_000));
+
+        // 첫 번째 서브도메인으로 인증서 생성
+        let auth1 = Authority::from_static("api.wildcard-test.com");
+        let cfg1 = ca.gen_server_config(&auth1, None).await.unwrap();
+
+        // 두 번째 서브도메인은 와일드카드 캐시에서 가져와야 함
+        let auth2 = Authority::from_static("www.wildcard-test.com");
+        let cfg2 = ca.gen_server_config(&auth2, None).await.unwrap();
+
+        // 동일한 ServerConfig 인스턴스를 공유해야 함
+        assert!(
+            Arc::ptr_eq(&cfg1, &cfg2),
+            "같은 루트 도메인의 서브도메인은 와일드카드 캐시를 공유해야 함"
+        );
+    }
+
+    /// 루트 도메인은 와일드카드 캐시를 사용하지 않는지 확인
+    #[tokio::test]
+    async fn root_domain_no_wildcard_sharing() {
+        let ca = Arc::new(build_ca(1_000));
+
+        let auth1 = Authority::from_static("example-root.com");
+        let cfg1 = ca.gen_server_config(&auth1, None).await.unwrap();
+
+        let auth2 = Authority::from_static("other-root.com");
+        let cfg2 = ca.gen_server_config(&auth2, None).await.unwrap();
+
+        // 다른 도메인이므로 다른 인스턴스
+        assert!(
+            !Arc::ptr_eq(&cfg1, &cfg2),
+            "다른 루트 도메인은 별도 인증서를 생성해야 함"
+        );
+    }
+
+    /// 메트릭이 올바르게 수집되는지 확인
+    #[tokio::test]
+    async fn metrics_recorded_on_gen_and_cache_hit() {
+        let ca = build_ca(1_000);
+        let authority = Authority::from_static("metrics-test.example.com");
+
+        // 첫 번째 요청: 생성
+        ca.gen_server_config(&authority, None).await.unwrap();
+
+        // 두 번째 요청: 캐시 히트
+        ca.gen_server_config(&authority, None).await.unwrap();
+
+        let metrics = ca.get_metrics();
+        let snap = metrics.snapshot();
+        assert!(snap.gen_count >= 1, "최소 1번 생성되어야 함");
+        assert!(snap.cache_hit_count >= 1, "최소 1번 캐시 히트여야 함");
+        assert!(snap.avg_gen_duration_us > 0, "생성 시간이 기록되어야 함");
+    }
+
     /// CertEvent enum이 올바르게 동작하는지 확인
     #[test]
     fn cert_event_variants() {

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
@@ -118,41 +118,8 @@ impl RcgenAuthority {
 
         info!("[SERVER-CONFIG] ServerConfig 빌더 생성 완료");
 
-        // ALPN 미러링: 상류 서버의 ALPN 협상 결과를 반영
-        server_cfg.alpn_protocols = if let Some(ref upstream) = upstream_cert {
-            if let Some(ref negotiated) = upstream.negotiated_alpn {
-                // 상류 서버가 협상한 프로토콜 우선, 나머지도 포함
-                let mut protocols = vec![negotiated.clone()];
-                #[cfg(feature = "http2")]
-                if negotiated != b"h2" {
-                    protocols.push(b"h2".to_vec());
-                }
-                if negotiated != b"http/1.1" {
-                    protocols.push(b"http/1.1".to_vec());
-                }
-                info!(
-                    "[SERVER-CONFIG] ALPN 미러링 적용: {:?}",
-                    protocols
-                        .iter()
-                        .map(|p| String::from_utf8_lossy(p).to_string())
-                        .collect::<Vec<_>>()
-                );
-                protocols
-            } else {
-                vec![
-                    #[cfg(feature = "http2")]
-                    b"h2".to_vec(),
-                    b"http/1.1".to_vec(),
-                ]
-            }
-        } else {
-            vec![
-                #[cfg(feature = "http2")]
-                b"h2".to_vec(),
-                b"http/1.1".to_vec(),
-            ]
-        };
-
+        server_cfg.alpn_protocols =
+            crate::certificate_authority::build_alpn_protocols(upstream_cert);
         info!(
             "[SERVER-CONFIG] ALPN 프로토콜 설정: {:?}",
             server_cfg.alpn_protocols
@@ -179,14 +146,65 @@ impl CertificateAuthority for RcgenAuthority {
         authority: &Authority,
         upstream_cert: Option<&UpstreamCertInfo>,
     ) -> Result<Arc<ServerConfig>, Box<dyn std::error::Error + Send + Sync>> {
-        // Thundering herd 방지: 동일 authority에 대해 동시 요청이 오면 하나만 생성하고 나머지는 대기
-        self.cache
-            .try_get_with(
+        // 캐시 히트: 정확히 일치하는 authority
+        if let Some(cfg) = self.cache.get(authority).await {
+            self.metrics.record_cache_hit();
+            return Ok(cfg);
+        }
+
+        // 캐시 히트: 와일드카드 authority (*.example.com)로 서브도메인 공유
+        if let Some(wildcard) = crate::certificate_authority::wildcard_authority(authority) {
+            if let Some(cfg) = self.cache.get(&wildcard).await {
+                // 와일드카드 캐시 히트 → 원본 authority에도 저장
+                self.cache.insert(authority.clone(), Arc::clone(&cfg)).await;
+                self.metrics.record_cache_hit();
+                return Ok(cfg);
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let timeout_duration =
+            std::time::Duration::from_secs(crate::certificate_authority::CERT_GEN_TIMEOUT_SECS);
+
+        let result = tokio::time::timeout(
+            timeout_duration,
+            self.cache.try_get_with(
                 authority.clone(),
                 self.build_server_config(authority, upstream_cert),
-            )
-            .await
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })
+            ),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(cfg)) => {
+                self.metrics.record_gen(start.elapsed());
+                // 와일드카드 키에도 저장하여 같은 루트 도메인의 서브도메인이 공유
+                if let Some(wildcard) = crate::certificate_authority::wildcard_authority(authority)
+                {
+                    self.cache.insert(wildcard, Arc::clone(&cfg)).await;
+                }
+                Ok(cfg)
+            }
+            Ok(Err(e)) => {
+                self.metrics.record_failure();
+                Err(Box::from(e.to_string()))
+            }
+            Err(_) => {
+                self.metrics.record_failure();
+                warn!(
+                    "[SERVER-CONFIG] 인증서 생성 타임아웃 ({}초): {}. upstream 정보 없이 재시도",
+                    crate::certificate_authority::CERT_GEN_TIMEOUT_SECS,
+                    authority
+                );
+                // 타임아웃 시 upstream 정보 없이 ECDSA(기본)로 폴백
+                self.cache
+                    .try_get_with(authority.clone(), self.build_server_config(authority, None))
+                    .await
+                    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                        Box::from(format!("타임아웃 후 폴백도 실패: {}", e))
+                    })
+            }
+        }
     }
 
     fn get_ca_cert_der(&self) -> Option<Vec<u8>> {

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
@@ -196,13 +196,15 @@ impl CertificateAuthority for RcgenAuthority {
                     crate::certificate_authority::CERT_GEN_TIMEOUT_SECS,
                     authority
                 );
-                // 타임아웃 시 upstream 정보 없이 ECDSA(기본)로 폴백
-                self.cache
-                    .try_get_with(authority.clone(), self.build_server_config(authority, None))
-                    .await
-                    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                // 타임아웃된 첫 번째 try_get_with의 init이 아직 실행 중일 수 있으므로
+                // try_get_with 대신 직접 생성하여 레이스 컨디션 방지
+                let cfg = self.build_server_config(authority, None).await.map_err(
+                    |e| -> Box<dyn std::error::Error + Send + Sync> {
                         Box::from(format!("타임아웃 후 폴백도 실패: {}", e))
-                    })
+                    },
+                )?;
+                self.cache.insert(authority.clone(), Arc::clone(&cfg)).await;
+                Ok(cfg)
             }
         }
     }


### PR DESCRIPTION
## 개요

인증서 시스템의 성능 및 관측 가능성을 개선합니다. 메트릭 수집, 생성 타임아웃, ALPN 코드 중복 제거, 와일드카드 캐시 공유를 추가합니다.

## 변경 내용

### 수정된 파일

- `certificate_authority/mod.rs` — `CertMetrics`, `CertMetricsSnapshot`, `wildcard_authority()`, `build_alpn_protocols()` 추가, 테스트 19건 추가
- `rcgen_authority/mod.rs` — `RcgenAuthority`에 `metrics` 필드 및 `get_metrics()` 메서드 추가
- `rcgen_authority/trait_impl.rs` — 메트릭 기록, 타임아웃 + ECDSA 폴백, 와일드카드 캐시 조회/저장, ALPN 공통 함수 호출
- `openssl_authority/trait_impl.rs` — ALPN 공통 함수 호출
- `rcgen_authority/tests.rs` — 와일드카드 캐시 공유, 루트 도메인 분리, 메트릭 수집 테스트

## 구현 상세

### 1. 인증서 생성 메트릭

Atomic 카운터 기반 lock-free 메트릭:
- `gen_count`: 인증서 생성 횟수
- `cache_hit_count`: 캐시 히트 횟수
- `gen_failure_count`: 생성 실패 횟수
- `total_gen_duration_us`: 총 생성 소요시간 (μs)
- `avg_gen_duration_us()`: 평균 생성 시간
- `cache_hit_rate()`: 캐시 히트율 (0.0~1.0)
- `snapshot()`: JSON 직렬화 가능한 스냅샷

### 2. 인증서 생성 타임아웃 (10초)

```
요청 → try_get_with(10초 타임아웃)
       → 타임아웃 발생 시 upstream 정보 없이 ECDSA(기본)로 폴백
       → RSA 키 생성이 느릴 때 연결이 무한 대기하는 것을 방지
```

### 3. ALPN 미러링 공통 함수

rcgen/openssl `trait_impl.rs`에 완전히 동일하게 복사되어 있던 ALPN 프로토콜 구성 로직을 `build_alpn_protocols()` 공통 함수로 추출했습니다.

### 4. 와일드카드 캐시 공유

```
api.example.com → 인증서 생성 → 캐시에 저장
                               + *.example.com 키에도 저장

www.example.com → 캐시 조회 (미스)
                → *.example.com 와일드카드 캐시 조회 → 히트!
                → 같은 인증서 재사용 (새로 생성하지 않음)
```

- IP 주소, 루트 도메인(example.com), localhost는 와일드카드 대상에서 제외
- 이미 와일드카드인 도메인(*.example.com)은 그대로 유지

## 테스트

총 84개 테스트 통과 (기존 65개 + 신규 19개):

### wildcard_authority 유닛 테스트
- [x] `wildcard_subdomain` — api.example.com → *.example.com
- [x] `wildcard_deep_subdomain` — a.b.example.com → *.b.example.com
- [x] `wildcard_preserves_port` — 포트 번호 보존
- [x] `wildcard_root_domain_returns_none` — 루트 도메인 제외
- [x] `wildcard_ip_returns_none` — IP 주소 제외
- [x] `wildcard_already_wildcard` — 이미 와일드카드면 그대로
- [x] `wildcard_localhost_returns_none` — localhost 제외

### build_alpn_protocols 유닛 테스트
- [x] `alpn_no_upstream` — 기본 프로토콜 목록
- [x] `alpn_with_negotiated_h2` — h2 협상 시 h2 우선
- [x] `alpn_with_negotiated_http11` — http/1.1 협상 시 중복 방지
- [x] `alpn_no_negotiated` — 협상 결과 없을 때 기본값

### CertMetrics 유닛 테스트
- [x] `metrics_initial_state` — 초기 상태 검증
- [x] `metrics_record_gen` — 생성 기록 검증
- [x] `metrics_cache_hit_rate` — 캐시 히트율 계산 정확성
- [x] `metrics_record_failure` — 실패 기록 검증
- [x] `metrics_snapshot_serializable` — JSON 직렬화 가능 확인

### 통합 테스트
- [x] `wildcard_cache_sharing` — 서브도메인 간 Arc::ptr_eq 캐시 공유
- [x] `root_domain_no_wildcard_sharing` — 루트 도메인 분리 확인
- [x] `metrics_recorded_on_gen_and_cache_hit` — 메트릭 end-to-end 검증