### PR TITLE
fix(desktop): Tauri core mock에 Resource/Channel 추가로 CI 테스트 복구

### DIFF
--- a/desktop/test/mocks/tauri.ts
+++ b/desktop/test/mocks/tauri.ts
@@ -1,8 +1,23 @@
 import { mock } from "bun:test";
 
 // @tauri-apps/api/core mock
+// @tauri-apps/plugin-fs 2.5.0+가 Resource/Channel을 import하므로 함께 export해야 모듈 로드 실패로 인한 테스트 간 side-effect를 막을 수 있다.
+class MockResource {
+  readonly rid = 0;
+  async close() {}
+}
+class MockChannel {
+  onmessage?: (msg: unknown) => void;
+  id = 0;
+}
 mock.module("@tauri-apps/api/core", () => ({
   invoke: mock(() => Promise.resolve()),
+  Resource: MockResource,
+  Channel: MockChannel,
+  transformCallback: mock(() => 0),
+  convertFileSrc: mock((path: string) => path),
+  isTauri: mock(() => false),
+  SERIALIZE_TO_IPC_FN: "__TAURI_TO_IPC_KEY__",
 }));
 
 // @tauri-apps/api/event mock


### PR DESCRIPTION
## 개요

직전 PR #334로 `@tauri-apps/plugin-fs`를 2.4.5 → 2.5.0으로 올린 뒤 CI Frontend Unit Test가 실패. 테스트 mock 누락이 원인이므로 복구.

## 원인 분석

- `@tauri-apps/plugin-fs` 2.5.0부터 `@tauri-apps/api/core`에서 `Resource`, `Channel`을 import
- `test/mocks/tauri.ts`의 `@tauri-apps/api/core` mock에는 `invoke`만 export돼 있어서 plugin-fs 모듈 로드 단계에서 `SyntaxError: Export named 'Resource' not found` 발생
- 이 unhandled error가 같은 bun test 프로세스에서 돌아가는 다른 테스트들의 모듈 상태/zustand 초기화 타이밍에 영향
- 결과적으로 CI Linux에서 `map-rule-store > addRule > 규칙 추가 시 syncToProxy가 호출된다` 테스트가 `rules: []`를 수신하며 실패 (로컬 macOS에선 타이밍 차이로 flake가 드러나지 않음)

## 변경 내용

### 수정된 파일

- `desktop/test/mocks/tauri.ts`
  - `@tauri-apps/api/core` mock에 `Resource`/`Channel` 더미 클래스, `transformCallback`, `convertFileSrc`, `isTauri`, `SERIALIZE_TO_IPC_FN` 추가
  - mock 의도를 설명하는 주석 추가

## 테스트

- [x] `bun run test` 로컬 통과 (583 pass / 0 fail — 이전 대비 +12 테스트 복원)
- [x] 이전 har-export 관련 `Unhandled error between tests` 소거 확인
- [ ] CI Frontend Unit Test 통과 확인