### PR TITLE
fix(config): CI bun 버전을 1.3.11로 업데이트

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build with Rspress
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Install dependencies

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/openssl-bundling-test.yml
+++ b/.github/workflows/openssl-bundling-test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## 개요

PR #334 머지 이후 CI `Frontend Unit Test`에서 `map-rule-store > addRule > syncToProxy가 호출된다` 테스트가 실패 중. 로컬 bun 1.3.11에서는 재현되지 않으며 CI bun 1.3.10만의 모듈 평가/실행 순서 이슈로 보임.

PR #335에서 Tauri mock에 Resource/Channel을 추가했지만 해당 테스트는 `test/lib/har-export`와 독립이라 여전히 실패. 근본적으로는 bun 1.3.10에서 dynamic import + `mock.module` 상호작용이 zustand store의 rules 상태를 늦게 반영시키는 것으로 추정.

가장 확실한 수정은 CI를 로컬과 동일한 1.3.11로 맞추는 것.

## 변경 내용

- `.github/workflows/frontend-test.yml`
- `.github/workflows/javascript-lint.yml`
- `.github/workflows/e2e-test.yml`
- `.github/workflows/openssl-bundling-test.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/release.yml`

모두 `bun-version: "1.3.10"` → `"1.3.11"`.

## 테스트

- [x] 로컬 bun 1.3.11에서 `bun test --preload ./test/setup.ts test/stores test/entities` 169 pass / 0 fail
- [ ] CI Frontend Unit Test 통과 확인