### PR TITLE
fix(desktop): rule 스토어 테스트 zustand persist rehydrate race 수정

### DIFF
--- a/desktop/test/stores/intercept-rule-store.test.ts
+++ b/desktop/test/stores/intercept-rule-store.test.ts
@@ -64,10 +64,28 @@ describe("intercept-rule-store", () => {
 
   beforeEach(async () => {
     useInterceptRuleStore = await getStore();
+    // zustand persist rehydrate가 async로 진행되는데, CI Linux에서 타이밍이
+    // addRule과 겹쳐 rules를 덮어쓰는 race condition이 관측되어 명시적으로 대기한다.
+    if (!useInterceptRuleStore.persist.hasHydrated()) {
+      await new Promise<void>((resolve) => {
+        const unsub = useInterceptRuleStore.persist.onFinishHydration(() => {
+          unsub();
+          resolve();
+        });
+      });
+    }
     // 스토어 초기화
     useInterceptRuleStore.setState({ rules: [] });
     // map-rule-store도 초기화 (syncAllRulesToProxy가 모든 스토어를 합치므로)
     const { useMapRuleStore } = await import("../../src/shared/stores/map-rule-store");
+    if (!useMapRuleStore.persist.hasHydrated()) {
+      await new Promise<void>((resolve) => {
+        const unsub = useMapRuleStore.persist.onFinishHydration(() => {
+          unsub();
+          resolve();
+        });
+      });
+    }
     useMapRuleStore.setState({ rules: [] });
     (invoke as ReturnType<typeof mock>).mockClear();
   });

--- a/desktop/test/stores/map-rule-store.test.ts
+++ b/desktop/test/stores/map-rule-store.test.ts
@@ -48,6 +48,16 @@ describe("map-rule-store", () => {
 
   beforeEach(async () => {
     useMapRuleStore = await getStore();
+    // zustand persist rehydrate가 async로 진행되는데, CI Linux에서 타이밍이
+    // addRule과 겹쳐 rules를 덮어쓰는 race condition이 관측되어 명시적으로 대기한다.
+    if (!useMapRuleStore.persist.hasHydrated()) {
+      await new Promise<void>((resolve) => {
+        const unsub = useMapRuleStore.persist.onFinishHydration(() => {
+          unsub();
+          resolve();
+        });
+      });
+    }
     useMapRuleStore.setState({ rules: [] });
     (invoke as ReturnType<typeof mock>).mockClear();
   });


### PR DESCRIPTION
## 개요

PR #334 이후 CI Frontend Unit Test에서 map-rule-store 테스트가 지속 실패. bun 버전 맞춤(#336)과 Tauri mock 보강(#335)으로도 해결되지 않아 실제 원인(rehydrate race)을 찾아 수정.

## 원인 분석

- `createTauriStorage.getItem`이 async Promise 기반
- zustand `persist` middleware가 모듈 평가 직후 rehydrate를 백그라운드에서 진행
- 테스트 `beforeEach`에서 `setState({rules:[]})` → rehydrate가 pending일 수 있음
- 이후 `addRule(rule)` → rules=[rule]로 set
- 그 직후 rehydrate 완료되며 storage 값(빈 상태)으로 rules를 덮어씀
- 결과: `syncToProxy`가 `invoke("update_intercept_rules_v2", { rules: [] })`로 호출돼 assertion 실패
- macOS와 Linux의 microtask 스케줄링 차이로 CI(Linux)에서만 race 노출

## 변경 내용

- `desktop/test/stores/map-rule-store.test.ts` — beforeEach에서 `persist.hasHydrated()` 확인 후 `onFinishHydration` 대기
- `desktop/test/stores/intercept-rule-store.test.ts` — 동일 패턴을 자기 스토어 + map-rule-store 양쪽에 적용 (두 스토어가 같은 프로세스의 `ruleGetters`에 등록되므로 둘 다 rehydrate 완료 필요)

## 테스트

- [x] 로컬 `bun test --preload ./test/setup.ts test/stores test/entities` 169 pass / 0 fail
- [ ] CI Frontend Unit Test 통과 확인