### PR TITLE
fix(desktop): rule 스토어 테스트에서 ruleGetters를 명시적으로 격리

### DIFF
--- a/desktop/test/stores/intercept-rule-store.test.ts
+++ b/desktop/test/stores/intercept-rule-store.test.ts
@@ -64,8 +64,7 @@ describe("intercept-rule-store", () => {
 
   beforeEach(async () => {
     useInterceptRuleStore = await getStore();
-    // zustand persist rehydrate가 async로 진행되는데, CI Linux에서 타이밍이
-    // addRule과 겹쳐 rules를 덮어쓰는 race condition이 관측되어 명시적으로 대기한다.
+    // zustand persist rehydrate 완료를 명시적으로 대기 (CI Linux에서 race condition 방지).
     if (!useInterceptRuleStore.persist.hasHydrated()) {
       await new Promise<void>((resolve) => {
         const unsub = useInterceptRuleStore.persist.onFinishHydration(() => {
@@ -74,19 +73,11 @@ describe("intercept-rule-store", () => {
         });
       });
     }
-    // 스토어 초기화
+    // ruleGetters를 이번 테스트의 store 인스턴스로만 격리한다.
+    const { _resetForTest, registerRuleStore } = await import("../../src/shared/stores/sync-rules");
+    _resetForTest();
+    registerRuleStore(() => useInterceptRuleStore.getState());
     useInterceptRuleStore.setState({ rules: [] });
-    // map-rule-store도 초기화 (syncAllRulesToProxy가 모든 스토어를 합치므로)
-    const { useMapRuleStore } = await import("../../src/shared/stores/map-rule-store");
-    if (!useMapRuleStore.persist.hasHydrated()) {
-      await new Promise<void>((resolve) => {
-        const unsub = useMapRuleStore.persist.onFinishHydration(() => {
-          unsub();
-          resolve();
-        });
-      });
-    }
-    useMapRuleStore.setState({ rules: [] });
     (invoke as ReturnType<typeof mock>).mockClear();
   });
 

--- a/desktop/test/stores/map-rule-store.test.ts
+++ b/desktop/test/stores/map-rule-store.test.ts
@@ -48,8 +48,7 @@ describe("map-rule-store", () => {
 
   beforeEach(async () => {
     useMapRuleStore = await getStore();
-    // zustand persist rehydrate가 async로 진행되는데, CI Linux에서 타이밍이
-    // addRule과 겹쳐 rules를 덮어쓰는 race condition이 관측되어 명시적으로 대기한다.
+    // zustand persist rehydrate 완료를 명시적으로 대기 (CI Linux에서 race condition 방지).
     if (!useMapRuleStore.persist.hasHydrated()) {
       await new Promise<void>((resolve) => {
         const unsub = useMapRuleStore.persist.onFinishHydration(() => {
@@ -58,6 +57,12 @@ describe("map-rule-store", () => {
         });
       });
     }
+    // ruleGetters를 이번 테스트의 store 인스턴스로만 격리한다.
+    // (다른 테스트 파일에서 등록된 store getter가 남아 있으면 syncAllRulesToProxy
+    // 결과에 섞여들어 assertion이 불안정해진다.)
+    const { _resetForTest, registerRuleStore } = await import("../../src/shared/stores/sync-rules");
+    _resetForTest();
+    registerRuleStore(() => useMapRuleStore.getState());
     useMapRuleStore.setState({ rules: [] });
     (invoke as ReturnType<typeof mock>).mockClear();
   });


### PR DESCRIPTION
## 개요

PR #337에서 hydrate race를 수정했지만 CI에서 여전히 `map-rule-store > addRule > 규칙 추가 시 syncToProxy가 호출된다`가 실패. store의 rules는 addRule 후 정상적으로 [rule]인데 `syncAllRulesToProxy`에서 조회한 `ruleGetters`는 빈 배열을 반환. 결국 ruleGetters가 가리키는 getter와 현재 테스트가 쓰는 store 인스턴스가 CI 환경에서 불일치하는 것으로 판단.

## 수정

- `intercept-rule-store.test.ts`, `map-rule-store.test.ts`의 beforeEach에서 `sync-rules._resetForTest()`를 호출해 `ruleGetters`를 완전히 초기화
- 바로 직후 현재 테스트가 사용하는 store의 getter를 `registerRuleStore(() => store.getState())`로 수동 재등록
- 이로써 `syncAllRulesToProxy`는 항상 이번 테스트의 store만 조회

PR #337의 hydrate 대기 코드는 유지 (race 예방).

## 테스트

- [x] 로컬 `bun test --preload ./test/setup.ts test/stores test/entities` 169 pass / 0 fail
- [ ] CI Frontend Unit Test 통과 확인