### PR TITLE
Harden automatic TLS passthrough

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
@@ -51,6 +55,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,6 +35,11 @@ jobs:
           toolchain: stable
           cache: true
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/openssl-bundling-test.yml
+++ b/.github/workflows/openssl-bundling-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          cache: true
+          cache: false
 
       - name: Install OpenSSL via Homebrew
         run: brew install openssl@3

--- a/.github/workflows/openssl-bundling-test.yml
+++ b/.github/workflows/openssl-bundling-test.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Install OpenSSL via Homebrew
         run: brew install openssl@3
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/crates/mcp_server/src/store.rs
+++ b/crates/mcp_server/src/store.rs
@@ -1,3 +1,8 @@
-pub use cheolsu_ops::context::{
-    OpsStore as Store, StoreConfig, MAX_SSE_EVENTS, MAX_TRANSACTIONS, MAX_WS_MESSAGES,
-};
+pub use cheolsu_ops::context::OpsStore as Store;
+
+#[allow(dead_code)]
+pub const MAX_TRANSACTIONS: usize = cheolsu_ops::context::MAX_TRANSACTIONS;
+#[allow(dead_code)]
+pub const MAX_WS_MESSAGES: usize = cheolsu_ops::context::MAX_WS_MESSAGES;
+#[allow(dead_code)]
+pub const MAX_SSE_EVENTS: usize = cheolsu_ops::context::MAX_SSE_EVENTS;

--- a/crates/proxy_daemon/src/client_handler/commands.rs
+++ b/crates/proxy_daemon/src/client_handler/commands.rs
@@ -326,9 +326,13 @@ pub(super) async fn handle_command(cmd: ClientCommand, ctx: &CommandState) -> bo
             let list = s.tls_passthrough.list_bypassed();
             let entries: Vec<TlsPassthroughEntry> = list
                 .into_iter()
-                .map(|(host, failure_count)| TlsPassthroughEntry {
-                    host,
-                    failure_count,
+                .map(|entry| TlsPassthroughEntry {
+                    host: entry.host,
+                    failure_count: entry.failure_count,
+                    active: entry.active,
+                    blocked_by_never_passthrough: entry.blocked_by_never_passthrough,
+                    last_failure_unix_secs: entry.last_failure_unix_secs,
+                    expires_at_unix_secs: entry.expires_at_unix_secs,
                 })
                 .collect();
             let response = DaemonMessage::TlsPassthroughUpdated { entries };

--- a/crates/proxy_daemon/src/daemon/mod.rs
+++ b/crates/proxy_daemon/src/daemon/mod.rs
@@ -308,8 +308,9 @@ async fn daemon_main(port: u16, host: String) -> i32 {
     let _metrics_handle = metrics_aggregator.spawn_aggregation_loop(metric_event_rx);
 
     // TLS 자동 학습 바이패스 초기화 (변경 알림 채널 포함)
-    let (tls_change_tx, mut tls_change_rx) =
-        tokio::sync::mpsc::channel::<Vec<(String, u32)>>(TLS_CHANGE_CHANNEL_CAPACITY);
+    let (tls_change_tx, mut tls_change_rx) = tokio::sync::mpsc::channel::<
+        Vec<proxyapi_v2::tls_passthrough::TlsPassthroughSnapshot>,
+    >(TLS_CHANGE_CHANNEL_CAPACITY);
     let app_dir = app_support_dir().ok();
     let passthrough_path = app_dir.as_ref().map(|dir| dir.join("tls_passthrough.json"));
     // Never Passthrough 변경 알림 채널
@@ -336,12 +337,14 @@ async fn daemon_main(port: u16, host: String) -> i32 {
             while let Some(entries) = tls_change_rx.recv().await {
                 let tls_entries: Vec<crate::protocol::TlsPassthroughEntry> = entries
                     .into_iter()
-                    .map(
-                        |(host, failure_count)| crate::protocol::TlsPassthroughEntry {
-                            host,
-                            failure_count,
-                        },
-                    )
+                    .map(|entry| crate::protocol::TlsPassthroughEntry {
+                        host: entry.host,
+                        failure_count: entry.failure_count,
+                        active: entry.active,
+                        blocked_by_never_passthrough: entry.blocked_by_never_passthrough,
+                        last_failure_unix_secs: entry.last_failure_unix_secs,
+                        expires_at_unix_secs: entry.expires_at_unix_secs,
+                    })
                     .collect();
                 let msg = DaemonMessage::TlsPassthroughUpdated {
                     entries: tls_entries,

--- a/crates/proxy_daemon/src/protocol/ssl.rs
+++ b/crates/proxy_daemon/src/protocol/ssl.rs
@@ -93,4 +93,12 @@ pub struct SslProxyingEntry {
 pub struct TlsPassthroughEntry {
     pub host: String,
     pub failure_count: u32,
+    #[serde(default)]
+    pub active: bool,
+    #[serde(default)]
+    pub blocked_by_never_passthrough: bool,
+    #[serde(default)]
+    pub last_failure_unix_secs: u64,
+    #[serde(default)]
+    pub expires_at_unix_secs: Option<u64>,
 }

--- a/crates/proxyapi_v2/src/tls_passthrough.rs
+++ b/crates/proxyapi_v2/src/tls_passthrough.rs
@@ -5,7 +5,45 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info, warn};
+
+/// 자동 TLS passthrough가 활성화되기 위해 필요한 최소 연속 실패 횟수.
+pub const MIN_FAILURES_FOR_BYPASS: u32 = 2;
+
+/// 자동 TLS passthrough 실패 기록 유효 시간. 만료된 기록은 우회에 사용하지 않습니다.
+pub const FAILURE_TTL_SECS: u64 = 60 * 60;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct FailureRecord {
+    failure_count: u32,
+    last_failure_unix_secs: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+enum StoredFailureRecord {
+    Count(u32),
+    Record(FailureRecord),
+}
+
+/// TLS passthrough 실패/우회 상태 스냅샷.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsPassthroughSnapshot {
+    pub host: String,
+    pub failure_count: u32,
+    pub active: bool,
+    pub blocked_by_never_passthrough: bool,
+    pub last_failure_unix_secs: u64,
+    pub expires_at_unix_secs: Option<u64>,
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// 와일드카드 도메인 패턴 매칭 (* = 임의 문자열, ? = 단일 문자)
 /// 대소문자 구분 없음
@@ -30,15 +68,15 @@ fn wildcard_match_recursive(pattern: &[u8], text: &[u8]) -> bool {
 }
 
 /// TLS 핸드셰이크 실패 도메인을 기록하고, 이후 연결 시 자동으로 바이패스(터널)하는 모듈.
-/// 한 번이라도 실패한 도메인은 이후 MITM 없이 TCP 파이프로 통과시킵니다.
+/// 일정 횟수 이상 연속 실패한 도메인은 제한된 시간 동안 MITM 없이 TCP 파이프로 통과시킵니다.
 #[derive(Clone)]
 pub struct TlsPassthrough {
-    /// host → 실패 횟수 (lock-free concurrent map)
-    failures: Arc<DashMap<String, u32>>,
+    /// host → 실패 기록 (lock-free concurrent map)
+    failures: Arc<DashMap<String, FailureRecord>>,
     /// 저장 파일 경로
     file_path: Option<PathBuf>,
     /// 변경 사항 알림 채널 (실시간 UI 업데이트용)
-    change_tx: Option<tokio::sync::mpsc::Sender<Vec<(String, u32)>>>,
+    change_tx: Option<tokio::sync::mpsc::Sender<Vec<TlsPassthroughSnapshot>>>,
 
     /// 절대 패스스루하지 않는 도메인 패턴 목록 (lock-free concurrent set)
     never_passthrough: Arc<DashSet<String>>,
@@ -60,13 +98,22 @@ impl TlsPassthrough {
         if let Some(ref path) = file_path {
             if path.exists() {
                 if let Ok(data) = std::fs::read_to_string(path) {
-                    if let Ok(loaded) = serde_json::from_str::<HashMap<String, u32>>(&data) {
+                    if let Ok(loaded) =
+                        serde_json::from_str::<HashMap<String, StoredFailureRecord>>(&data)
+                    {
                         info!(
                             "[TLS-PASSTHROUGH] 이전 기록 로드: {}개 도메인",
                             loaded.len()
                         );
                         for (k, v) in loaded {
-                            failures.insert(k, v);
+                            let record = match v {
+                                StoredFailureRecord::Count(failure_count) => FailureRecord {
+                                    failure_count,
+                                    last_failure_unix_secs: now_unix_secs(),
+                                },
+                                StoredFailureRecord::Record(record) => record,
+                            };
+                            failures.insert(k, record);
                         }
                     }
                 }
@@ -109,7 +156,7 @@ impl TlsPassthrough {
     /// 변경 알림 채널을 설정합니다.
     pub fn with_change_notifier(
         mut self,
-        tx: tokio::sync::mpsc::Sender<Vec<(String, u32)>>,
+        tx: tokio::sync::mpsc::Sender<Vec<TlsPassthroughSnapshot>>,
     ) -> Self {
         self.change_tx = Some(tx);
         self
@@ -124,17 +171,35 @@ impl TlsPassthrough {
         self
     }
 
-    /// 해당 호스트가 failures에 존재하는지 확인 (lock-free, 동기)
+    /// 해당 호스트가 현재 자동 우회 대상인지 확인 (lock-free, 동기)
     pub fn has_failure(&self, host: &str) -> bool {
-        self.failures.contains_key(host)
+        self.should_bypass_host(host)
     }
 
     /// failures 스냅샷 생성
-    fn snapshot_failures(&self) -> Vec<(String, u32)> {
+    fn snapshot_failures(&self) -> Vec<TlsPassthroughSnapshot> {
+        let now = now_unix_secs();
         self.failures
             .iter()
-            .map(|entry| (entry.key().clone(), *entry.value()))
+            .map(|entry| self.snapshot_for(entry.key(), entry.value(), now))
             .collect()
+    }
+
+    fn snapshot_for(&self, host: &str, record: &FailureRecord, now: u64) -> TlsPassthroughSnapshot {
+        let blocked_by_never_passthrough = self.is_never_passthrough(host);
+        let expires_at = record.last_failure_unix_secs + FAILURE_TTL_SECS;
+        let expired = now >= expires_at;
+        let active = record.failure_count >= MIN_FAILURES_FOR_BYPASS
+            && !blocked_by_never_passthrough
+            && !expired;
+        TlsPassthroughSnapshot {
+            host: host.to_string(),
+            failure_count: record.failure_count,
+            active,
+            blocked_by_never_passthrough,
+            last_failure_unix_secs: record.last_failure_unix_secs,
+            expires_at_unix_secs: if expired { None } else { Some(expires_at) },
+        }
     }
 
     /// never_passthrough 스냅샷 생성
@@ -168,7 +233,7 @@ impl TlsPassthrough {
     }
 
     /// flush 내부 구현 — 스냅샷을 반환하여 재사용 가능
-    fn flush_failures_inner(&self) -> Vec<(String, u32)> {
+    fn flush_failures_inner(&self) -> Vec<TlsPassthroughSnapshot> {
         let was_dirty = self.failures_dirty.swap(false, Ordering::Acquire);
         let snapshot = self.snapshot_failures();
         if was_dirty {
@@ -176,7 +241,11 @@ impl TlsPassthrough {
                 if let Some(parent) = path.parent() {
                     let _ = std::fs::create_dir_all(parent);
                 }
-                let map: HashMap<String, u32> = snapshot.iter().cloned().collect();
+                let map: HashMap<String, FailureRecord> = self
+                    .failures
+                    .iter()
+                    .map(|entry| (entry.key().clone(), entry.value().clone()))
+                    .collect();
                 match serde_json::to_string_pretty(&map) {
                     Ok(json) => {
                         if let Err(e) = std::fs::write(path, json) {
@@ -248,11 +317,19 @@ impl TlsPassthrough {
         let host = authority.host().to_string();
 
         let is_never = self.is_never_passthrough(&host);
+        let now = now_unix_secs();
 
         let count = {
-            let mut entry = self.failures.entry(host.clone()).or_insert(0);
-            *entry += 1;
-            *entry
+            let mut entry = self.failures.entry(host.clone()).or_insert(FailureRecord {
+                failure_count: 0,
+                last_failure_unix_secs: now,
+            });
+            if now.saturating_sub(entry.last_failure_unix_secs) > FAILURE_TTL_SECS {
+                entry.failure_count = 0;
+            }
+            entry.failure_count += 1;
+            entry.last_failure_unix_secs = now;
+            entry.failure_count
         };
 
         if is_never {
@@ -262,19 +339,15 @@ impl TlsPassthrough {
             );
         } else {
             warn!(
-                "[TLS-PASSTHROUGH] 핸드셰이크 실패 기록: {} ({}회)",
-                host, count
+                "[TLS-PASSTHROUGH] 핸드셰이크 실패 기록: {} ({}회, 자동 우회 임계값 {}회)",
+                host, count, MIN_FAILURES_FOR_BYPASS
             );
         }
 
         self.notify_failures_and_mark_dirty();
     }
 
-    /// 해당 도메인을 바이패스해야 하는지 확인 (1회 이상 실패 && never_passthrough 아닌 경우)
-    pub fn should_bypass(&self, authority: &Authority) -> bool {
-        let host = authority.host();
-
-        // never_passthrough에 해당하면 절대 바이패스하지 않음
+    fn should_bypass_host(&self, host: &str) -> bool {
         if self.is_never_passthrough(host) {
             debug!(
                 "[TLS-PASSTHROUGH] never_passthrough 설정으로 바이패스 차단: {}",
@@ -283,16 +356,36 @@ impl TlsPassthrough {
             return false;
         }
 
-        match self.failures.get(host) {
-            Some(count) => {
-                debug!(
-                    "[TLS-PASSTHROUGH] 바이패스 적용: {} (이전 실패 {}회)",
-                    host, *count
-                );
-                true
-            }
-            None => false,
+        let Some(record) = self.failures.get(host) else {
+            return false;
+        };
+        let now = now_unix_secs();
+        let expires_at = record.last_failure_unix_secs + FAILURE_TTL_SECS;
+        if now >= expires_at {
+            debug!(
+                "[TLS-PASSTHROUGH] 만료된 실패 기록으로 바이패스 미적용: {}",
+                host
+            );
+            return false;
         }
+        if record.failure_count < MIN_FAILURES_FOR_BYPASS {
+            debug!(
+                "[TLS-PASSTHROUGH] 실패 횟수 부족으로 바이패스 대기: {} ({}/{})",
+                host, record.failure_count, MIN_FAILURES_FOR_BYPASS
+            );
+            return false;
+        }
+
+        debug!(
+            "[TLS-PASSTHROUGH] 바이패스 적용: {} (이전 실패 {}회)",
+            host, record.failure_count
+        );
+        true
+    }
+
+    /// 해당 도메인을 바이패스해야 하는지 확인 (임계값 이상 실패 && 만료 전 && never_passthrough 아닌 경우)
+    pub fn should_bypass(&self, authority: &Authority) -> bool {
+        self.should_bypass_host(authority.host())
     }
 
     /// 핸드셰이크 성공 시 실패 기록에서 제거
@@ -305,7 +398,7 @@ impl TlsPassthrough {
     }
 
     /// 현재 바이패스 목록 조회
-    pub fn list_bypassed(&self) -> Vec<(String, u32)> {
+    pub fn list_bypassed(&self) -> Vec<TlsPassthroughSnapshot> {
         self.snapshot_failures()
     }
 
@@ -369,6 +462,8 @@ mod tests {
         assert!(!passthrough.should_bypass(&authority));
 
         passthrough.record_failure(&authority);
+        assert!(!passthrough.should_bypass(&authority));
+        passthrough.record_failure(&authority);
         assert!(passthrough.should_bypass(&authority));
     }
 
@@ -377,6 +472,7 @@ mod tests {
         let passthrough = TlsPassthrough::new(None);
         let authority: Authority = "example.com:443".parse().unwrap();
 
+        passthrough.record_failure(&authority);
         passthrough.record_failure(&authority);
         assert!(passthrough.should_bypass(&authority));
 
@@ -390,6 +486,7 @@ mod tests {
         let auth1: Authority = "apple.com:443".parse().unwrap();
         let auth2: Authority = "github.com:443".parse().unwrap();
 
+        passthrough.record_failure(&auth1);
         passthrough.record_failure(&auth1);
         assert!(passthrough.should_bypass(&auth1));
         assert!(!passthrough.should_bypass(&auth2));
@@ -421,6 +518,7 @@ mod tests {
             let passthrough = TlsPassthrough::new(Some(file_path.clone()));
             let authority: Authority = "pinned.example.com:443".parse().unwrap();
             passthrough.record_failure(&authority);
+            passthrough.record_failure(&authority);
             passthrough.flush_all();
         }
 
@@ -446,7 +544,8 @@ mod tests {
 
         let list = passthrough.list_bypassed();
         assert_eq!(list.len(), 1);
-        assert_eq!(list[0].1, 3);
+        assert_eq!(list[0].failure_count, 3);
+        assert!(list[0].active);
     }
 
     #[test]
@@ -456,6 +555,7 @@ mod tests {
         let auth2: Authority = "google.com:443".parse().unwrap();
 
         passthrough.record_failure(&auth1);
+        passthrough.record_failure(&auth2);
         passthrough.record_failure(&auth2);
 
         passthrough.clear_domain("apple.com");
@@ -475,10 +575,14 @@ mod tests {
         passthrough.record_failure(&auth2);
 
         let mut list = passthrough.list_bypassed();
-        list.sort_by(|a, b| a.0.cmp(&b.0));
+        list.sort_by(|a, b| a.host.cmp(&b.host));
         assert_eq!(list.len(), 2);
-        assert_eq!(list[0], ("a.com".to_string(), 1));
-        assert_eq!(list[1], ("b.com".to_string(), 2));
+        assert_eq!(list[0].host, "a.com");
+        assert_eq!(list[0].failure_count, 1);
+        assert!(!list[0].active);
+        assert_eq!(list[1].host, "b.com");
+        assert_eq!(list[1].failure_count, 2);
+        assert!(list[1].active);
     }
 
     #[test]
@@ -491,8 +595,9 @@ mod tests {
 
         let entries = rx.try_recv().unwrap();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].0, "example.com");
-        assert_eq!(entries[0].1, 1);
+        assert_eq!(entries[0].host, "example.com");
+        assert_eq!(entries[0].failure_count, 1);
+        assert!(!entries[0].active);
     }
 
     #[test]
@@ -510,6 +615,8 @@ mod tests {
         // 실패 횟수는 기록됨
         let list = passthrough.list_bypassed();
         assert_eq!(list.len(), 1);
+        assert!(!list[0].active);
+        assert!(list[0].blocked_by_never_passthrough);
     }
 
     #[test]
@@ -521,6 +628,7 @@ mod tests {
         passthrough.set_never_passthrough(vec!["blocked.com".to_string()]);
 
         passthrough.record_failure(&auth_blocked);
+        passthrough.record_failure(&auth_allowed);
         passthrough.record_failure(&auth_allowed);
 
         assert!(!passthrough.should_bypass(&auth_blocked));

--- a/desktop/src-tauri/src/proxy_v2/tls_passthrough.rs
+++ b/desktop/src-tauri/src/proxy_v2/tls_passthrough.rs
@@ -1,7 +1,42 @@
 use super::state::get_command_sender;
 use super::ProxyV2State;
 use proxy_daemon::{ClientCommand, LearnedTlsStrategy, TlsConfigRule, TlsPassthroughEntry};
+use serde::Deserialize;
 use tauri::State;
+
+const MIN_FAILURES_FOR_BYPASS: u32 = 2;
+const FAILURE_TTL_SECS: u64 = 60 * 60;
+
+#[derive(Deserialize)]
+struct StoredTlsFailureRecord {
+    failure_count: u32,
+    last_failure_unix_secs: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StoredTlsFailure {
+    Count(u32),
+    Record(StoredTlsFailureRecord),
+}
+
+fn wildcard_matches(pattern: &str, text: &str) -> bool {
+    fn inner(pattern: &[u8], text: &[u8]) -> bool {
+        match (pattern.first(), text.first()) {
+            (None, None) => true,
+            (Some(b'*'), _) => {
+                inner(&pattern[1..], text) || (!text.is_empty() && inner(pattern, &text[1..]))
+            }
+            (Some(b'?'), Some(_)) => inner(&pattern[1..], &text[1..]),
+            (Some(a), Some(b)) if a == b => inner(&pattern[1..], &text[1..]),
+            _ => false,
+        }
+    }
+    inner(
+        pattern.to_ascii_lowercase().as_bytes(),
+        text.to_ascii_lowercase().as_bytes(),
+    )
+}
 
 #[tauri::command]
 pub(crate) async fn get_tls_passthrough_list(
@@ -20,13 +55,47 @@ pub(crate) async fn get_tls_passthrough_list(
     }
     let data = std::fs::read_to_string(&path)
         .map_err(|e| format!("TLS passthrough 파일 읽기 실패: {}", e))?;
-    let map: std::collections::HashMap<String, u32> =
+    let map: std::collections::HashMap<String, StoredTlsFailure> =
         serde_json::from_str(&data).map_err(|e| format!("JSON 파싱 실패: {}", e))?;
+    let never_passthrough_path = proxy_daemon::daemon::app_support_dir()
+        .map(|d| d.join("never_passthrough.json"))
+        .map_err(|e| format!("데이터 디렉토리를 찾을 수 없습니다: {}", e))?;
+    let never_passthrough: Vec<String> = if never_passthrough_path.exists() {
+        std::fs::read_to_string(&never_passthrough_path)
+            .ok()
+            .and_then(|data| serde_json::from_str(&data).ok())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
     let mut entries: Vec<TlsPassthroughEntry> = map
         .into_iter()
-        .map(|(host, failure_count)| TlsPassthroughEntry {
-            host,
-            failure_count,
+        .map(|(host, stored)| {
+            let (failure_count, last_failure_unix_secs) = match stored {
+                StoredTlsFailure::Count(count) => (count, now),
+                StoredTlsFailure::Record(record) => {
+                    (record.failure_count, record.last_failure_unix_secs)
+                }
+            };
+            let expires_at = last_failure_unix_secs + FAILURE_TTL_SECS;
+            let expired = now >= expires_at;
+            let blocked_by_never_passthrough = never_passthrough
+                .iter()
+                .any(|pattern| wildcard_matches(pattern, &host));
+            TlsPassthroughEntry {
+                host,
+                failure_count,
+                active: failure_count >= MIN_FAILURES_FOR_BYPASS
+                    && !expired
+                    && !blocked_by_never_passthrough,
+                blocked_by_never_passthrough,
+                last_failure_unix_secs,
+                expires_at_unix_secs: if expired { None } else { Some(expires_at) },
+            }
         })
         .collect();
     entries.sort_by(|a, b| a.host.cmp(&b.host));

--- a/desktop/src/locales/en/messages.po
+++ b/desktop/src/locales/en/messages.po
@@ -74,6 +74,7 @@ msgstr "Abort"
 msgid "Action"
 msgstr "Action"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:489
 #: src/pages/script/ui/script-page.tsx:170
 #: src/pages/settings/ui/components/custom-ca-section.tsx:134
 msgid "Active"
@@ -99,7 +100,7 @@ msgstr "Actual"
 #: src/pages/settings/ui/components/client-tags-section.tsx:111
 #: src/pages/settings/ui/components/never-passthrough-section.tsx:75
 #: src/pages/settings/ui/components/ssl-proxying-section.tsx:213
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:276
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:284
 msgid "Add"
 msgstr "Add"
 
@@ -107,7 +108,7 @@ msgstr "Add"
 msgid "Add breakpoint rules to pause HTTP requests/responses for inspection."
 msgstr "Add breakpoint rules to pause HTTP requests/responses for inspection."
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:263
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:271
 msgid "Add built-in domain pattern..."
 msgstr "Add built-in domain pattern..."
 
@@ -351,6 +352,10 @@ msgstr "Block Cookies"
 msgid "Block QUIC"
 msgstr "Block QUIC"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:485
+msgid "Blocked"
+msgstr "Blocked"
+
 #: src/features/intercept-rule-form/ui/block-action-fields.tsx:22
 #: src/features/intercept-rule-form/ui/modify-request-fields.tsx:18
 #: src/features/intercept-rule-form/ui/modify-response-fields.tsx:29
@@ -404,7 +409,7 @@ msgid "Browse"
 msgstr "Browse"
 
 #. placeholder {0}: defaultPassthroughEntries.length
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:247
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:255
 msgid "Built-in Passthrough Domains ({0})"
 msgstr "Built-in Passthrough Domains ({0})"
 
@@ -450,7 +455,7 @@ msgstr "calls"
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:267
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:228
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:492
-#: src/pages/log-viewer/ui/logs-page.tsx:495
+#: src/pages/log-viewer/ui/logs-page.tsx:535
 #: src/pages/reverse-proxy/ui/reverse-proxy-page.tsx:139
 #: src/pages/settings/ui/components/shortcut-section.tsx:117
 msgid "Cancel"
@@ -527,7 +532,7 @@ msgid "Cleaning..."
 msgstr "Cleaning..."
 
 #: src/features/query-filter-editor/ui/query-builder.tsx:383
-#: src/pages/log-viewer/ui/logs-page.tsx:262
+#: src/pages/log-viewer/ui/logs-page.tsx:268
 #: src/pages/script/ui/script-page.tsx:299
 #: src/pages/settings/ui/components/request-client-cert-section.tsx:72
 msgid "Clear"
@@ -539,7 +544,7 @@ msgid "Clear all"
 msgstr "Clear all"
 
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:199
-#: src/pages/log-viewer/ui/logs-page.tsx:292
+#: src/pages/log-viewer/ui/logs-page.tsx:298
 #: src/pages/server-replay/ui/server-replay-page.tsx:71
 #: src/pages/settings/ui/components/tls-config-section.tsx:113
 #: src/shared/ui/rule-list-page.tsx:69
@@ -760,17 +765,17 @@ msgid "Delay between requests (ms)"
 msgstr "Delay between requests (ms)"
 
 #: src/features/query-filter-editor/ui/filter-preset-menu.tsx:110
-#: src/pages/log-viewer/ui/logs-page.tsx:271
-#: src/pages/log-viewer/ui/logs-page.tsx:499
+#: src/pages/log-viewer/ui/logs-page.tsx:277
+#: src/pages/log-viewer/ui/logs-page.tsx:539
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: selectedFile?.name
-#: src/pages/log-viewer/ui/logs-page.tsx:489
+#: src/pages/log-viewer/ui/logs-page.tsx:529
 msgid "Delete \"{0}\"? This action cannot be undone."
 msgstr "Delete \"{0}\"? This action cannot be undone."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:486
+#: src/pages/log-viewer/ui/logs-page.tsx:526
 msgid "Delete Log File"
 msgstr "Delete Log File"
 
@@ -819,7 +824,7 @@ msgstr "Disconnected"
 msgid "Display CONNECT tunnel requests in the network list"
 msgstr "Display CONNECT tunnel requests in the network list"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:445
+#: src/pages/log-viewer/ui/logs-page.tsx:459
 msgid "Domain"
 msgstr "Domain"
 
@@ -831,6 +836,10 @@ msgstr "Domain-specific Certificates"
 msgid "Domain-specific TLS engine rules. Domains matched here use OpenSSL instead of rustls for compatibility."
 msgstr "Domain-specific TLS engine rules. Domains matched here use OpenSSL instead of rustls for compatibility."
 
+#: src/pages/log-viewer/ui/logs-page.tsx:415
+msgid "Domains are automatically tunneled without MITM only after repeated TLS handshake failures. Failed-but-inactive entries are retained for diagnostics."
+msgstr "Domains are automatically tunneled without MITM only after repeated TLS handshake failures. Failed-but-inactive entries are retained for diagnostics."
+
 #: src/pages/settings/ui/components/never-passthrough-section.tsx:59
 msgid "Domains in this list will never fall back to passthrough when TLS handshake fails. The proxy will keep trying to intercept these domains, allowing you to see the actual error instead of silently bypassing."
 msgstr "Domains in this list will never fall back to passthrough when TLS handshake fails. The proxy will keep trying to intercept these domains, allowing you to see the actual error instead of silently bypassing."
@@ -838,10 +847,6 @@ msgstr "Domains in this list will never fall back to passthrough when TLS handsh
 #: src/pages/settings/ui/components/ssl-proxying-section.tsx:218
 msgid "Domains in this list will NOT be intercepted (pass-through). Built-in domains can be managed below."
 msgstr "Domains in this list will NOT be intercepted (pass-through). Built-in domains can be managed below."
-
-#: src/pages/log-viewer/ui/logs-page.tsx:409
-msgid "Domains that failed TLS handshake are automatically tunneled without MITM decryption. You can remove entries to retry MITM for specific domains."
-msgstr "Domains that failed TLS handshake are automatically tunneled without MITM decryption. You can remove entries to retry MITM for specific domains."
 
 #: src/pages/settings/ui/components/tls-config-section.tsx:103
 msgid "Domains that failed with the default TLS engine are recorded here. On the next connection, the alternate engine will be used automatically."
@@ -917,6 +922,10 @@ msgstr "Edit Rule"
 #: src/pages/script/ui/script-page.tsx:198
 msgid "Editor"
 msgstr "Editor"
+
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:231
+msgid "Empty whitelist currently means all HTTPS traffic is intercepted. Add at least one enabled domain to limit SSL Proxying to selected hosts."
+msgstr "Empty whitelist currently means all HTTPS traffic is intercepted. Add at least one enabled domain to limit SSL Proxying to selected hosts."
 
 #: src/pages/settings/ui/components/certificate-settings.tsx:303
 msgid "Enable full trust for the Cheolsu Proxy CA certificate"
@@ -1027,6 +1036,10 @@ msgstr "Expected"
 msgid "Expired"
 msgstr "Expired"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:468
+msgid "Expires"
+msgstr "Expires"
+
 #: src/widgets/network-header/ui/network-controls.tsx:113
 msgid "Export HAR"
 msgstr "Export HAR"
@@ -1084,7 +1097,7 @@ msgstr "Failed to send"
 msgid "Failed to toggle spec: {0}"
 msgstr "Failed to toggle spec: {0}"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:448
+#: src/pages/log-viewer/ui/logs-page.tsx:462
 msgid "Failures"
 msgstr "Failures"
 
@@ -1096,11 +1109,11 @@ msgstr "File"
 msgid "Filter by client IP, tag, or auth user"
 msgstr "Filter by client IP, tag, or auth user"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:418
+#: src/pages/log-viewer/ui/logs-page.tsx:432
 msgid "Filter domains..."
 msgstr "Filter domains..."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:373
+#: src/pages/log-viewer/ui/logs-page.tsx:379
 msgid "Filter log lines..."
 msgstr "Filter log lines..."
 
@@ -1416,7 +1429,7 @@ msgstr "Learned TLS Strategies"
 msgid "Light"
 msgstr "Light"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:380
+#: src/pages/log-viewer/ui/logs-page.tsx:386
 msgid "lines"
 msgstr "lines"
 
@@ -1467,8 +1480,8 @@ msgstr "Local File Path"
 msgid "localhost, 127.0.0.1, *.internal.com"
 msgstr "localhost, 127.0.0.1, *.internal.com"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:309
-#: src/pages/log-viewer/ui/logs-page.tsx:336
+#: src/pages/log-viewer/ui/logs-page.tsx:315
+#: src/pages/log-viewer/ui/logs-page.tsx:342
 msgid "Log Files"
 msgstr "Log Files"
 
@@ -1476,7 +1489,7 @@ msgstr "Log Files"
 msgid "Logical OR:"
 msgstr "Logical OR:"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:247
+#: src/pages/log-viewer/ui/logs-page.tsx:253
 #: src/shared/app-sidebar/model/consts.ts:134
 msgid "Logs"
 msgstr "Logs"
@@ -1748,7 +1761,7 @@ msgstr "No intercept rules"
 msgid "No learned strategies yet. They will appear after TLS fallback events."
 msgstr "No learned strategies yet. They will appear after TLS fallback events."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:341
+#: src/pages/log-viewer/ui/logs-page.tsx:347
 msgid "No log files found"
 msgstr "No log files found"
 
@@ -1756,7 +1769,7 @@ msgstr "No log files found"
 msgid "No map rules"
 msgstr "No map rules"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:437
+#: src/pages/log-viewer/ui/logs-page.tsx:451
 msgid "No matching domains"
 msgstr "No matching domains"
 
@@ -1812,7 +1825,7 @@ msgstr "No specs loaded. Add an OpenAPI/Swagger spec file to start contract test
 msgid "No timing data available"
 msgstr "No timing data available"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:433
+#: src/pages/log-viewer/ui/logs-page.tsx:447
 msgid "No TLS passthrough entries"
 msgstr "No TLS passthrough entries"
 
@@ -1888,7 +1901,7 @@ msgstr "Open <0>{CERT_DOWNLOAD_URL}</0> in Safari"
 msgid "Open <0>{CERT_DOWNLOAD_URL}</0> in your device browser"
 msgstr "Open <0>{CERT_DOWNLOAD_URL}</0> in your device browser"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:275
+#: src/pages/log-viewer/ui/logs-page.tsx:281
 msgid "Open Directory"
 msgstr "Open Directory"
 
@@ -1987,6 +2000,10 @@ msgstr "Payload"
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:190
 msgid "pending"
 msgstr "pending"
+
+#: src/pages/log-viewer/ui/logs-page.tsx:493
+msgid "Pending"
+msgstr "Pending"
 
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:317
 msgid "Pending Breakpoints"
@@ -2137,8 +2154,8 @@ msgstr "Received (Server → Client)"
 msgid "Referrer"
 msgstr "Referrer"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:258
-#: src/pages/log-viewer/ui/logs-page.tsx:283
+#: src/pages/log-viewer/ui/logs-page.tsx:264
+#: src/pages/log-viewer/ui/logs-page.tsx:289
 #: src/pages/settings/ui/components/certificate-settings.tsx:387
 msgid "Refresh"
 msgstr "Refresh"
@@ -2336,7 +2353,7 @@ msgstr "Restart proxy to apply changes"
 msgid "Restart proxy to use auto-generated CA"
 msgstr "Restart proxy to use auto-generated CA"
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:250
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:258
 msgid "Restore Defaults"
 msgstr "Restore Defaults"
 
@@ -2506,7 +2523,7 @@ msgstr "Script unloaded"
 msgid "Security"
 msgstr "Security"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:396
+#: src/pages/log-viewer/ui/logs-page.tsx:402
 msgid "Select a log file to view its contents"
 msgstr "Select a log file to view its contents"
 
@@ -2734,6 +2751,7 @@ msgstr "Starts background server connection immediately after ClientHello detect
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:52
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:118
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:123
+#: src/pages/log-viewer/ui/logs-page.tsx:465
 #: src/shared/app-sidebar/ui/sidebar-status.tsx:39
 #: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:69
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:151
@@ -2831,7 +2849,7 @@ msgstr "The DER certificate file will download automatically"
 msgid "Theme"
 msgstr "Theme"
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:254
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:262
 msgid "These domains are automatically excluded from HTTPS interception to prevent OAuth/authentication failures. You can toggle, add, or remove domains."
 msgstr "These domains are automatically excluded from HTTPS interception to prevent OAuth/authentication failures. You can toggle, add, or remove domains."
 
@@ -2866,7 +2884,7 @@ msgstr "TLS Engine Rules"
 msgid "TLS fallback — learned strategy used"
 msgstr "TLS fallback — learned strategy used"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:320
+#: src/pages/log-viewer/ui/logs-page.tsx:326
 msgid "TLS Passthrough"
 msgstr "TLS Passthrough"
 
@@ -3071,7 +3089,7 @@ msgstr "Variables"
 msgid "Version"
 msgstr "Version"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:250
+#: src/pages/log-viewer/ui/logs-page.tsx:256
 msgid "View and manage application log files"
 msgstr "View and manage application log files"
 

--- a/desktop/src/locales/ko/messages.po
+++ b/desktop/src/locales/ko/messages.po
@@ -74,6 +74,7 @@ msgstr "중단"
 msgid "Action"
 msgstr "동작"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:489
 #: src/pages/script/ui/script-page.tsx:170
 #: src/pages/settings/ui/components/custom-ca-section.tsx:134
 msgid "Active"
@@ -99,7 +100,7 @@ msgstr "실제값"
 #: src/pages/settings/ui/components/client-tags-section.tsx:111
 #: src/pages/settings/ui/components/never-passthrough-section.tsx:75
 #: src/pages/settings/ui/components/ssl-proxying-section.tsx:213
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:276
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:284
 msgid "Add"
 msgstr "추가"
 
@@ -107,7 +108,7 @@ msgstr "추가"
 msgid "Add breakpoint rules to pause HTTP requests/responses for inspection."
 msgstr "HTTP 요청/응답을 검사하기 위해 일시 정지할 Breakpoint 규칙을 추가하세요."
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:263
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:271
 msgid "Add built-in domain pattern..."
 msgstr "기본 제외 도메인 패턴 추가..."
 
@@ -351,6 +352,10 @@ msgstr "쿠키 차단"
 msgid "Block QUIC"
 msgstr "QUIC 차단"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:485
+msgid "Blocked"
+msgstr ""
+
 #: src/features/intercept-rule-form/ui/block-action-fields.tsx:22
 #: src/features/intercept-rule-form/ui/modify-request-fields.tsx:18
 #: src/features/intercept-rule-form/ui/modify-response-fields.tsx:29
@@ -404,7 +409,7 @@ msgid "Browse"
 msgstr "찾아보기"
 
 #. placeholder {0}: defaultPassthroughEntries.length
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:247
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:255
 msgid "Built-in Passthrough Domains ({0})"
 msgstr "기본 제외 도메인 ({0})"
 
@@ -450,7 +455,7 @@ msgstr "호출"
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:267
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:228
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:492
-#: src/pages/log-viewer/ui/logs-page.tsx:495
+#: src/pages/log-viewer/ui/logs-page.tsx:535
 #: src/pages/reverse-proxy/ui/reverse-proxy-page.tsx:139
 #: src/pages/settings/ui/components/shortcut-section.tsx:117
 msgid "Cancel"
@@ -527,7 +532,7 @@ msgid "Cleaning..."
 msgstr "정리 중..."
 
 #: src/features/query-filter-editor/ui/query-builder.tsx:383
-#: src/pages/log-viewer/ui/logs-page.tsx:262
+#: src/pages/log-viewer/ui/logs-page.tsx:268
 #: src/pages/script/ui/script-page.tsx:299
 #: src/pages/settings/ui/components/request-client-cert-section.tsx:72
 msgid "Clear"
@@ -539,7 +544,7 @@ msgid "Clear all"
 msgstr "전체 삭제"
 
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:199
-#: src/pages/log-viewer/ui/logs-page.tsx:292
+#: src/pages/log-viewer/ui/logs-page.tsx:298
 #: src/pages/server-replay/ui/server-replay-page.tsx:71
 #: src/pages/settings/ui/components/tls-config-section.tsx:113
 #: src/shared/ui/rule-list-page.tsx:69
@@ -760,17 +765,17 @@ msgid "Delay between requests (ms)"
 msgstr "요청 간 딜레이 (ms)"
 
 #: src/features/query-filter-editor/ui/filter-preset-menu.tsx:110
-#: src/pages/log-viewer/ui/logs-page.tsx:271
-#: src/pages/log-viewer/ui/logs-page.tsx:499
+#: src/pages/log-viewer/ui/logs-page.tsx:277
+#: src/pages/log-viewer/ui/logs-page.tsx:539
 msgid "Delete"
 msgstr "삭제"
 
 #. placeholder {0}: selectedFile?.name
-#: src/pages/log-viewer/ui/logs-page.tsx:489
+#: src/pages/log-viewer/ui/logs-page.tsx:529
 msgid "Delete \"{0}\"? This action cannot be undone."
 msgstr "\"{0}\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:486
+#: src/pages/log-viewer/ui/logs-page.tsx:526
 msgid "Delete Log File"
 msgstr "로그 파일 삭제"
 
@@ -819,7 +824,7 @@ msgstr "연결 끊김"
 msgid "Display CONNECT tunnel requests in the network list"
 msgstr "CONNECT 터널 요청을 네트워크 목록에 표시합니다"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:445
+#: src/pages/log-viewer/ui/logs-page.tsx:459
 msgid "Domain"
 msgstr "도메인"
 
@@ -831,6 +836,10 @@ msgstr "도메인별 인증서"
 msgid "Domain-specific TLS engine rules. Domains matched here use OpenSSL instead of rustls for compatibility."
 msgstr "도메인별 TLS 엔진 규칙입니다. 호환성을 위해 여기에 매칭된 도메인은 rustls 대신 OpenSSL을 사용합니다."
 
+#: src/pages/log-viewer/ui/logs-page.tsx:415
+msgid "Domains are automatically tunneled without MITM only after repeated TLS handshake failures. Failed-but-inactive entries are retained for diagnostics."
+msgstr ""
+
 #: src/pages/settings/ui/components/never-passthrough-section.tsx:59
 msgid "Domains in this list will never fall back to passthrough when TLS handshake fails. The proxy will keep trying to intercept these domains, allowing you to see the actual error instead of silently bypassing."
 msgstr "이 목록의 도메인은 TLS 핸드셰이크 실패 시에도 패스스루로 우회하지 않습니다. 프록시가 계속 인터셉트를 시도하여 자동 우회 대신 실제 오류를 확인할 수 있습니다."
@@ -838,10 +847,6 @@ msgstr "이 목록의 도메인은 TLS 핸드셰이크 실패 시에도 패스�
 #: src/pages/settings/ui/components/ssl-proxying-section.tsx:218
 msgid "Domains in this list will NOT be intercepted (pass-through). Built-in domains can be managed below."
 msgstr "이 목록의 도메인은 인터셉트하지 않습니다 (패스스루). 기본 제외 도메인은 아래에서 관리할 수 있습니다."
-
-#: src/pages/log-viewer/ui/logs-page.tsx:409
-msgid "Domains that failed TLS handshake are automatically tunneled without MITM decryption. You can remove entries to retry MITM for specific domains."
-msgstr "TLS 핸드셰이크에 실패한 도메인은 MITM 복호화 없이 자동으로 터널링됩니다. 항목을 삭제하면 해당 도메인에 대해 MITM을 다시 시도합니다."
 
 #: src/pages/settings/ui/components/tls-config-section.tsx:103
 msgid "Domains that failed with the default TLS engine are recorded here. On the next connection, the alternate engine will be used automatically."
@@ -917,6 +922,10 @@ msgstr "규칙 수정"
 #: src/pages/script/ui/script-page.tsx:198
 msgid "Editor"
 msgstr "에디터"
+
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:231
+msgid "Empty whitelist currently means all HTTPS traffic is intercepted. Add at least one enabled domain to limit SSL Proxying to selected hosts."
+msgstr ""
 
 #: src/pages/settings/ui/components/certificate-settings.tsx:303
 msgid "Enable full trust for the Cheolsu Proxy CA certificate"
@@ -1027,6 +1036,10 @@ msgstr "기대값"
 msgid "Expired"
 msgstr "만료됨"
 
+#: src/pages/log-viewer/ui/logs-page.tsx:468
+msgid "Expires"
+msgstr ""
+
 #: src/widgets/network-header/ui/network-controls.tsx:113
 msgid "Export HAR"
 msgstr "HAR 내보내기"
@@ -1084,7 +1097,7 @@ msgstr "전송 실패"
 msgid "Failed to toggle spec: {0}"
 msgstr "스펙 전환 실패: {0}"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:448
+#: src/pages/log-viewer/ui/logs-page.tsx:462
 msgid "Failures"
 msgstr "실패 횟수"
 
@@ -1096,11 +1109,11 @@ msgstr "파일"
 msgid "Filter by client IP, tag, or auth user"
 msgstr "클라이언트 IP, 태그 또는 인증 사용자로 필터링"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:418
+#: src/pages/log-viewer/ui/logs-page.tsx:432
 msgid "Filter domains..."
 msgstr "도메인 검색..."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:373
+#: src/pages/log-viewer/ui/logs-page.tsx:379
 msgid "Filter log lines..."
 msgstr "로그 라인 필터..."
 
@@ -1416,7 +1429,7 @@ msgstr "학습된 TLS 전략"
 msgid "Light"
 msgstr "라이트"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:380
+#: src/pages/log-viewer/ui/logs-page.tsx:386
 msgid "lines"
 msgstr "줄"
 
@@ -1467,8 +1480,8 @@ msgstr "로컬 파일 경로"
 msgid "localhost, 127.0.0.1, *.internal.com"
 msgstr "localhost, 127.0.0.1, *.internal.com"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:309
-#: src/pages/log-viewer/ui/logs-page.tsx:336
+#: src/pages/log-viewer/ui/logs-page.tsx:315
+#: src/pages/log-viewer/ui/logs-page.tsx:342
 msgid "Log Files"
 msgstr "로그 파일"
 
@@ -1476,7 +1489,7 @@ msgstr "로그 파일"
 msgid "Logical OR:"
 msgstr "논리 OR:"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:247
+#: src/pages/log-viewer/ui/logs-page.tsx:253
 #: src/shared/app-sidebar/model/consts.ts:134
 msgid "Logs"
 msgstr "로그"
@@ -1748,7 +1761,7 @@ msgstr "인터셉트 규칙 없음"
 msgid "No learned strategies yet. They will appear after TLS fallback events."
 msgstr "아직 학습된 전략이 없습니다. TLS 폴백 이벤트 발생 후 표시됩니다."
 
-#: src/pages/log-viewer/ui/logs-page.tsx:341
+#: src/pages/log-viewer/ui/logs-page.tsx:347
 msgid "No log files found"
 msgstr "로그 파일을 찾을 수 없습니다"
 
@@ -1756,7 +1769,7 @@ msgstr "로그 파일을 찾을 수 없습니다"
 msgid "No map rules"
 msgstr "맵 규칙 없음"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:437
+#: src/pages/log-viewer/ui/logs-page.tsx:451
 msgid "No matching domains"
 msgstr "일치하는 도메인 없음"
 
@@ -1812,7 +1825,7 @@ msgstr "로드된 스펙이 없습니다. OpenAPI/Swagger 스펙 파일을 추�
 msgid "No timing data available"
 msgstr "타이밍 데이터 없음"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:433
+#: src/pages/log-viewer/ui/logs-page.tsx:447
 msgid "No TLS passthrough entries"
 msgstr "TLS Passthrough 항목이 없습니다"
 
@@ -1888,7 +1901,7 @@ msgstr "Safari에서 <0>{CERT_DOWNLOAD_URL}</0>을 여세요"
 msgid "Open <0>{CERT_DOWNLOAD_URL}</0> in your device browser"
 msgstr "기기 브라우저에서 <0>{CERT_DOWNLOAD_URL}</0>을 여세요"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:275
+#: src/pages/log-viewer/ui/logs-page.tsx:281
 msgid "Open Directory"
 msgstr "디렉토리 열기"
 
@@ -1987,6 +2000,10 @@ msgstr "페이로드"
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:190
 msgid "pending"
 msgstr "대기 중"
+
+#: src/pages/log-viewer/ui/logs-page.tsx:493
+msgid "Pending"
+msgstr ""
 
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:317
 msgid "Pending Breakpoints"
@@ -2137,8 +2154,8 @@ msgstr "수신 (서버 → 클라이언트)"
 msgid "Referrer"
 msgstr "리퍼러"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:258
-#: src/pages/log-viewer/ui/logs-page.tsx:283
+#: src/pages/log-viewer/ui/logs-page.tsx:264
+#: src/pages/log-viewer/ui/logs-page.tsx:289
 #: src/pages/settings/ui/components/certificate-settings.tsx:387
 msgid "Refresh"
 msgstr "새로고침"
@@ -2336,7 +2353,7 @@ msgstr "변경사항을 적용하려면 프록시를 재시작하세요"
 msgid "Restart proxy to use auto-generated CA"
 msgstr "자동 생성 CA를 사용하려면 프록시를 재시작하세요"
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:250
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:258
 msgid "Restore Defaults"
 msgstr "기본값 복원"
 
@@ -2506,7 +2523,7 @@ msgstr "스크립트가 언로드되었습니다"
 msgid "Security"
 msgstr "보안"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:396
+#: src/pages/log-viewer/ui/logs-page.tsx:402
 msgid "Select a log file to view its contents"
 msgstr "로그 파일을 선택하여 내용을 확인하세요"
 
@@ -2734,6 +2751,7 @@ msgstr "ClientHello 감지 직후 백그라운드에서 서버 연결을 시작�
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:52
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:118
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:123
+#: src/pages/log-viewer/ui/logs-page.tsx:465
 #: src/shared/app-sidebar/ui/sidebar-status.tsx:39
 #: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:69
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:151
@@ -2831,7 +2849,7 @@ msgstr "DER 인증서 파일이 자동으로 다운로드됩니다"
 msgid "Theme"
 msgstr "테마"
 
-#: src/pages/settings/ui/components/ssl-proxying-section.tsx:254
+#: src/pages/settings/ui/components/ssl-proxying-section.tsx:262
 msgid "These domains are automatically excluded from HTTPS interception to prevent OAuth/authentication failures. You can toggle, add, or remove domains."
 msgstr "OAuth/인증 실패를 방지하기 위해 HTTPS 인터셉트에서 자동으로 제외되는 도메인입니다. 토글, 추가, 삭제가 가능합니다."
 
@@ -2866,7 +2884,7 @@ msgstr "TLS 엔진 규칙"
 msgid "TLS fallback — learned strategy used"
 msgstr "TLS 폴백 — 학습된 전략 사용"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:320
+#: src/pages/log-viewer/ui/logs-page.tsx:326
 msgid "TLS Passthrough"
 msgstr "TLS Passthrough"
 
@@ -3071,7 +3089,7 @@ msgstr "변수"
 msgid "Version"
 msgstr "버전"
 
-#: src/pages/log-viewer/ui/logs-page.tsx:250
+#: src/pages/log-viewer/ui/logs-page.tsx:256
 msgid "View and manage application log files"
 msgstr "애플리케이션 로그 파일 조회 및 관리"
 

--- a/desktop/src/pages/log-viewer/ui/logs-page.tsx
+++ b/desktop/src/pages/log-viewer/ui/logs-page.tsx
@@ -30,6 +30,10 @@ interface LogFileInfo {
 interface TlsPassthroughEntry {
   host: string;
   failure_count: number;
+  active: boolean;
+  blocked_by_never_passthrough: boolean;
+  last_failure_unix_secs: number;
+  expires_at_unix_secs: number | null;
 }
 
 function formatDate(timestamp: number): string {
@@ -238,6 +242,8 @@ export function LogsPage() {
     return tlsEntries.filter((e) => e.host.toLowerCase().includes(lowerFilter));
   }, [tlsEntries, tlsFilter]);
 
+  const activeTlsCount = useMemo(() => tlsEntries.filter((e) => e.active).length, [tlsEntries]);
+
   return (
     <div className="flex-1 flex flex-col h-full overflow-hidden">
       <div className="p-6 pb-3">
@@ -318,9 +324,9 @@ export function LogsPage() {
           >
             <Shield className="w-3.5 h-3.5" />
             <Trans>TLS Passthrough</Trans>
-            {tlsEntries.length > 0 && (
+            {activeTlsCount > 0 && (
               <Badge variant="secondary" className="text-xs ml-1">
-                {tlsEntries.length}
+                {activeTlsCount}
               </Badge>
             )}
           </button>
@@ -407,10 +413,18 @@ export function LogsPage() {
             <div className="p-3 border-b space-y-2">
               <p className="text-sm text-muted-foreground">
                 <Trans>
-                  Domains that failed TLS handshake are automatically tunneled without MITM
-                  decryption. You can remove entries to retry MITM for specific domains.
+                  Domains are automatically tunneled without MITM only after repeated TLS handshake
+                  failures. Failed-but-inactive entries are retained for diagnostics.
                 </Trans>
               </p>
+              {tlsEntries.length > 0 && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Badge variant="secondary">{activeTlsCount} active</Badge>
+                  <Badge variant="outline">
+                    {tlsEntries.length - activeTlsCount} pending/blocked
+                  </Badge>
+                </div>
+              )}
               {tlsEntries.length > 0 && (
                 <div className="flex items-center gap-2">
                   <Search className="w-4 h-4 text-muted-foreground" />
@@ -447,6 +461,12 @@ export function LogsPage() {
                       <th className="p-3 font-medium w-[120px]">
                         <Trans>Failures</Trans>
                       </th>
+                      <th className="p-3 font-medium w-[150px]">
+                        <Trans>Status</Trans>
+                      </th>
+                      <th className="p-3 font-medium w-[180px]">
+                        <Trans>Expires</Trans>
+                      </th>
                       <th className="p-3 font-medium w-[80px]"></th>
                     </tr>
                   </thead>
@@ -458,6 +478,26 @@ export function LogsPage() {
                           <Badge variant="outline" className="text-xs">
                             {entry.failure_count}
                           </Badge>
+                        </td>
+                        <td className="p-3">
+                          {entry.blocked_by_never_passthrough ? (
+                            <Badge variant="outline" className="text-xs">
+                              <Trans>Blocked</Trans>
+                            </Badge>
+                          ) : entry.active ? (
+                            <Badge variant="secondary" className="text-xs">
+                              <Trans>Active</Trans>
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-xs">
+                              <Trans>Pending</Trans>
+                            </Badge>
+                          )}
+                        </td>
+                        <td className="p-3 text-xs text-muted-foreground">
+                          {entry.expires_at_unix_secs
+                            ? formatDate(entry.expires_at_unix_secs)
+                            : "-"}
                         </td>
                         <td className="p-3">
                           <Button

--- a/desktop/src/pages/settings/ui/components/ssl-proxying-section.tsx
+++ b/desktop/src/pages/settings/ui/components/ssl-proxying-section.tsx
@@ -226,6 +226,14 @@ export function SslProxyingSection() {
           </Trans>
         )}
       </p>
+      {mode === "whitelist" && enabledCount === 0 && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          <Trans>
+            Empty whitelist currently means all HTTPS traffic is intercepted. Add at least one
+            enabled domain to limit SSL Proxying to selected hosts.
+          </Trans>
+        </div>
+      )}
       <EntryList
         entries={entries}
         onToggle={entryHandlers.handleToggle}

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,6 @@
 # https://mise.jdx.dev/
 
 [tools]
-node = "latest"
+node = "24"
 bun = "latest"
 rust = "nightly"


### PR DESCRIPTION
## Summary
- require repeated TLS handshake failures before activating automatic passthrough
- persist TLS failure metadata with active, blocked, and expiry status while preserving old count-only files
- show active/pending/blocked TLS passthrough status in the logs UI
- warn when SSL Proxying whitelist mode has no enabled entries

## Verification
- cargo test -p proxyapi_v2 tls_passthrough --lib
- cargo test -p proxy_daemon ssl_proxying --lib
- cargo check -p proxy_daemon
- npm run --prefix desktop build

Note: cargo check -p cheolsu-proxy was not used as a blocker because the existing Tauri build script requires the missing bundled resource binaries/cheolsu-tui-aarch64-apple-darwin.