### PR TITLE
백엔드 High 버그 수정: 패닉/요청 무결성/압축 폭탄 (4건)

### DIFF
--- a/crates/cheolsu_ops/src/traffic.rs
+++ b/crates/cheolsu_ops/src/traffic.rs
@@ -173,7 +173,12 @@ pub fn get_websocket_messages(ctx: &OpsContext, p: GetWsMessagesParams) -> OpRes
                 WsDirection::ServerToClient => "←",
             };
             let payload = if msg.payload.len() > 200 {
-                format!("{}...", &msg.payload[..200])
+                // UTF-8 문자 경계에서 자르기(멀티바이트 경계 슬라이싱 패닉 방지)
+                let mut end = 200;
+                while end > 0 && !msg.payload.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...", &msg.payload[..end])
             } else {
                 msg.payload.clone()
             };

--- a/crates/proxy_daemon/src/intercept/actions.rs
+++ b/crates/proxy_daemon/src/intercept/actions.rs
@@ -251,6 +251,11 @@ impl LoggingHandler {
                     );
                     if let Some(new_body) = set_body {
                         use http_body_util::Full;
+                        // 바디를 교체하므로 stale content-length/encoding 헤더를 제거한다.
+                        // (제거하지 않으면 잘못된 content-length로 요청이 행/손상됨)
+                        crate::header_utils::clear_content_encoding_headers(
+                            current_req.headers_mut(),
+                        );
                         *current_req.body_mut() =
                             Body::from(Full::new(bytes::Bytes::from(new_body.clone())));
                     }

--- a/crates/proxy_v2_models/src/data_type/decompression.rs
+++ b/crates/proxy_v2_models/src/data_type/decompression.rs
@@ -2,18 +2,32 @@ use brotli::Decompressor;
 use flate2::read::GzDecoder;
 use std::io::Read;
 
+/// 압축 해제 결과의 최대 허용 크기(압축 폭탄 방지). 100 MiB.
+pub const MAX_DECOMPRESSED_SIZE: u64 = 100 * 1024 * 1024;
+
+/// 상한을 적용해 reader를 모두 읽는다. 상한 초과 시 에러를 반환한다.
+fn read_to_end_capped<R: Read>(reader: R) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut decompressed = Vec::new();
+    // MAX+1 바이트까지 읽어, MAX를 초과하면(=MAX+1 도달) 폭탄으로 간주한다.
+    reader
+        .take(MAX_DECOMPRESSED_SIZE + 1)
+        .read_to_end(&mut decompressed)?;
+    if decompressed.len() as u64 > MAX_DECOMPRESSED_SIZE {
+        return Err(format!(
+            "압축 해제 크기가 한도({} bytes)를 초과했습니다(압축 폭탄 의심)",
+            MAX_DECOMPRESSED_SIZE
+        )
+        .into());
+    }
+    Ok(decompressed)
+}
+
 /// GZIP 압축 해제 함수
 pub fn decompress_gzip(data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let mut decoder = GzDecoder::new(data);
-    let mut decompressed = Vec::new();
-    decoder.read_to_end(&mut decompressed)?;
-    Ok(decompressed)
+    read_to_end_capped(GzDecoder::new(data))
 }
 
 /// Brotli 압축 해제 함수
 pub fn decompress_brotli(data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let mut decoder = Decompressor::new(data, 4096);
-    let mut decompressed = Vec::new();
-    decoder.read_to_end(&mut decompressed)?;
-    Ok(decompressed)
+    read_to_end_capped(Decompressor::new(data, 4096))
 }

--- a/crates/proxyapi_v2/src/throttle.rs
+++ b/crates/proxyapi_v2/src/throttle.rs
@@ -124,7 +124,9 @@ impl TokenBucket {
 
     /// 다음 토큰이 생길 때까지 대기할 시간
     fn time_until_available(&self) -> Duration {
-        if self.tokens >= 1.0 {
+        // rate가 0 이하이면 나눗셈 결과가 inf/NaN이 되어 Duration::from_secs_f64가
+        // 패닉하므로 가드한다(ThrottledIo::new에서 rate>0만 버킷을 만들지만 방어적으로 둠).
+        if self.tokens >= 1.0 || self.rate <= 0.0 {
             return Duration::ZERO;
         }
         let needed = 1.0 - self.tokens;
@@ -166,8 +168,12 @@ impl<T> ThrottledIo<T> {
     pub fn new(inner: T, config: &ThrottleConfig) -> Self {
         Self {
             inner,
-            read_bucket: config.download_rate.map(TokenBucket::new),
-            write_bucket: config.upload_rate.map(TokenBucket::new),
+            // rate 0은 무제한(None)으로 취급해 0으로 나눗셈 패닉을 방지한다.
+            read_bucket: config
+                .download_rate
+                .filter(|&r| r > 0)
+                .map(TokenBucket::new),
+            write_bucket: config.upload_rate.filter(|&r| r > 0).map(TokenBucket::new),
             read_sleep: None,
             write_sleep: None,
             latency_applied: false,
@@ -348,6 +354,23 @@ mod tests {
             "Should take at least 2s, took {:?}",
             elapsed
         );
+    }
+
+    #[tokio::test]
+    async fn throttled_io_rate_zero_does_not_panic() {
+        // rate=0(Some(0))이어도 패닉 없이 무제한 패스스루로 동작해야 한다.
+        let data = b"hello world";
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let config = ThrottleConfig {
+            enabled: true,
+            download_rate: Some(0),
+            upload_rate: Some(0),
+            latency_ms: 0,
+        };
+        let mut throttled = ThrottledIo::new(cursor, &config);
+        let mut buf = vec![0u8; 32];
+        let n = throttled.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], data);
     }
 
     #[tokio::test]


### PR DESCRIPTION
전수조사에서 검증된 백엔드 High 버그 4건을 수정합니다.

| # | 버그 | 위치 | 수정 |
|---|---|---|---|
|H1|Throttle rate=0 → `Duration::from_secs_f64(inf)` 패닉(DoS)|`proxyapi_v2/throttle.rs`|rate>0만 버킷 생성 + 가드, 회귀 테스트 추가|
|H3|ModifyRequest set_body가 stale content-length 미갱신 → 요청 행/손상|`proxy_daemon/intercept/actions.rs`|바디 교체 직전 `clear_content_encoding_headers` 호출|
|H5|압축 해제 크기 무제한 → 압축 폭탄 OOM(DoS)|`proxy_v2_models/data_type/decompression.rs`|gzip/brotli 해제에 100MiB 상한, 초과 시 에러|
|H8|`get_websocket_messages` 멀티바이트 UTF-8 경계 패닉|`cheolsu_ops/traffic.rs`|char_boundary 기반 안전 절단|

## 검증
- ✅ `cargo build --workspace` / `cargo fmt --check`
- ✅ throttle 5 / decompression 7 / cheolsu_ops 15 테스트 통과 (0 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)