### PR TITLE
백엔드 High 보안 수정: 인증서 SAN 불일치/mTLS fail-open (2건)

### DIFF
--- a/crates/proxyapi_v2/src/certificate_authority/mod.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/mod.rs
@@ -147,6 +147,9 @@ pub struct CertMetricsSnapshot {
 /// 호스트에서 와일드카드 Authority를 추출합니다.
 /// `api.example.com:443` → `*.example.com:443`
 /// IP 주소나 TLD는 None을 반환합니다.
+// 현재 프로덕션 경로에서는 사용하지 않지만(와일드카드 캐시 공유가 SAN 불일치를 유발해 제거됨),
+// 재사용 가능성을 위해 검증된 유틸리티로 보존한다.
+#[allow(dead_code)]
 pub(crate) fn wildcard_authority(authority: &Authority) -> Option<Authority> {
     let host = authority.host();
 

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/tests.rs
@@ -401,23 +401,53 @@ mod tests {
         );
     }
 
-    /// 와일드카드 캐시 공유 테스트: 같은 루트 도메인의 서브도메인이 캐시를 공유하는지 확인
+    /// 형제 서브도메인은 인증서를 공유하지 않아야 한다.
+    /// (호스트 기반 SAN은 형제 서브도메인을 커버하지 않으므로, 공유하면 hostname mismatch 발생)
     #[tokio::test]
-    async fn wildcard_cache_sharing() {
+    async fn sibling_subdomains_not_shared() {
         let ca = Arc::new(build_ca(1_000));
 
         // 첫 번째 서브도메인으로 인증서 생성
         let auth1 = Authority::from_static("api.wildcard-test.com");
         let cfg1 = ca.gen_server_config(&auth1, None).await.unwrap();
 
-        // 두 번째 서브도메인은 와일드카드 캐시에서 가져와야 함
+        // 두 번째 서브도메인은 자신의 SAN을 가진 별도 인증서를 받아야 함
         let auth2 = Authority::from_static("www.wildcard-test.com");
         let cfg2 = ca.gen_server_config(&auth2, None).await.unwrap();
 
-        // 동일한 ServerConfig 인스턴스를 공유해야 함
+        // 서로 다른 ServerConfig 인스턴스여야 함(SAN 불일치 인증서 재사용 금지)
         assert!(
-            Arc::ptr_eq(&cfg1, &cfg2),
-            "같은 루트 도메인의 서브도메인은 와일드카드 캐시를 공유해야 함"
+            !Arc::ptr_eq(&cfg1, &cfg2),
+            "형제 서브도메인은 각자의 SAN 인증서를 받아야 하며 공유해서는 안 됨"
+        );
+
+        // 동일 authority 재요청은 캐시 히트로 같은 인스턴스를 반환해야 함
+        let cfg1_again = ca.gen_server_config(&auth1, None).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&cfg1, &cfg1_again),
+            "동일 authority는 캐시를 공유해야 함"
+        );
+    }
+
+    /// mTLS 필수(required=true)인데 CA가 비어 있으면 fail-closed로 연결을 거부해야 한다.
+    /// (fail-open으로 모든 클라이언트를 허용하면 인증 우회가 됨)
+    #[tokio::test]
+    async fn required_client_cert_without_ca_fails_closed() {
+        use crate::certificate_authority::rcgen_authority::ClientCertVerifyConfig;
+
+        let ca = build_ca(1_000);
+        ca.set_client_cert_verify(Some(ClientCertVerifyConfig {
+            enabled: true,
+            ca_certs: Vec::new(), // 검증할 CA 없음
+            required: true,
+        }))
+        .await;
+
+        let auth = Authority::from_static("mtls-test.example.com");
+        let result = ca.gen_server_config(&auth, None).await;
+        assert!(
+            result.is_err(),
+            "required=true + CA 없음이면 fail-closed로 Err를 반환해야 함"
         );
     }
 

--- a/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
+++ b/crates/proxyapi_v2/src/certificate_authority/rcgen_authority/trait_impl.rs
@@ -49,6 +49,18 @@ impl RcgenAuthority {
             let verify_config_guard = self.client_cert_verify.read().await;
             if let Some(ref verify_config) = *verify_config_guard {
                 if verify_config.enabled {
+                    if verify_config.required && verify_config.ca_certs.is_empty() {
+                        // mTLS 필수(required)인데 검증할 CA가 비어 있음 = 잘못된 설정.
+                        // 여기서 allow_unauthenticated로 폴백하면 모든 클라이언트가 인증서 없이
+                        // 접속 가능한 fail-open 인증 우회가 된다. 보안상 연결을 거부(fail-closed)한다.
+                        error!(
+                            "[SERVER-CONFIG] client cert required=true이지만 CA가 비어 있음 — 연결 거부(fail-closed)"
+                        );
+                        return Err(
+                            "클라이언트 인증서가 필수(required)로 설정되었으나 검증할 CA 인증서가 없습니다. CA 경로/형식을 확인하세요."
+                                .to_string(),
+                        );
+                    }
                     if verify_config.ca_certs.is_empty() || !verify_config.required {
                         // 모든 인증서 수락 (선택적 요청) - 인증서 없어도 연결 허용
                         let verifier = tokio_rustls::rustls::server::WebPkiClientVerifier::builder(
@@ -152,16 +164,10 @@ impl CertificateAuthority for RcgenAuthority {
             return Ok(cfg);
         }
 
-        // 캐시 히트: 와일드카드 authority (*.example.com)로 서브도메인 공유
-        if let Some(wildcard) = crate::certificate_authority::wildcard_authority(authority) {
-            if let Some(cfg) = self.cache.get(&wildcard).await {
-                // 와일드카드 캐시 히트 → 원본 authority에도 저장
-                self.cache.insert(authority.clone(), Arc::clone(&cfg)).await;
-                self.metrics.record_cache_hit();
-                return Ok(cfg);
-            }
-        }
-
+        // NOTE: 과거에는 *.root 와일드카드 키로 서브도메인 간 ServerConfig를 공유했으나,
+        // 호스트 기반 SAN(host, *.host)은 형제 서브도메인(*.root)을 커버하지 않아
+        // www.example.com에 api.example.com용 인증서가 제공되는 hostname mismatch 버그가
+        // 있었다. 정확성을 위해 와일드카드 캐시 공유를 제거하고 authority별 캐시만 사용한다.
         let start = std::time::Instant::now();
         let timeout_duration =
             std::time::Duration::from_secs(crate::certificate_authority::CERT_GEN_TIMEOUT_SECS);
@@ -178,11 +184,6 @@ impl CertificateAuthority for RcgenAuthority {
         match result {
             Ok(Ok(cfg)) => {
                 self.metrics.record_gen(start.elapsed());
-                // 와일드카드 키에도 저장하여 같은 루트 도메인의 서브도메인이 공유
-                if let Some(wildcard) = crate::certificate_authority::wildcard_authority(authority)
-                {
-                    self.cache.insert(wildcard, Arc::clone(&cfg)).await;
-                }
                 Ok(cfg)
             }
             Ok(Err(e)) => {


### PR DESCRIPTION
검증된 백엔드 High 보안 버그 2건을 수정합니다.

| # | 버그 | 위치 | 수정 |
|---|---|---|---|
|H2|`*.root` 와일드카드 캐시 공유로 형제 서브도메인에 SAN 불일치 인증서 제공|`proxyapi_v2/.../rcgen_authority/trait_impl.rs`|와일드카드 캐시 공유 제거, authority별 캐시만 사용|
|H4|`required=true`인데 CA 비어 있으면 `allow_unauthenticated` fail-open(인증 우회)|`proxyapi_v2/.../rcgen_authority/trait_impl.rs`|required+CA없음 → 연결 거부(fail-closed)|

## 검증
- ✅ `cargo build --workspace` (경고 없음)
- ✅ certificate_authority 테스트 85건 통과 (신규 회귀 테스트 2건 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)