### PR TITLE
백엔드 High 수정: 스크립팅 엔진 안정성 (무한 루프/메모리 폭주 DoS 방지)

### DIFF
--- a/crates/scripting/src/engine/mod.rs
+++ b/crates/scripting/src/engine/mod.rs
@@ -27,6 +27,8 @@ deno_core::extension!(cheolsu_timer_ext, ops = [op_timer_sleep],);
 /// deno_core 기반 TypeScript/JavaScript 스크립팅 엔진
 pub struct ScriptEngine {
     runtime: JsRuntime,
+    /// 다른 스레드에서 실행 중인 스크립트를 강제 종료(terminate)하기 위한 핸들
+    isolate_handle: v8::IsolateHandle,
     has_on_request: bool,
     has_on_response: bool,
     has_on_ws_message: bool,
@@ -45,17 +47,46 @@ impl ScriptEngine {
             ..Default::default()
         });
 
+        let isolate_handle = runtime.v8_isolate().thread_safe_handle();
+
+        // 힙 한계 근접 시 스크립트 실행을 강제 종료하여 프로세스 전체 abort를 방지한다.
+        // (heap_limits만 설정하면 한계 초과 시 V8이 프로세스를 abort시켜 데몬 전체가 죽는다)
+        {
+            let oom_handle = isolate_handle.clone();
+            runtime.add_near_heap_limit_callback(move |current_limit, _initial_limit| {
+                oom_handle.terminate_execution();
+                // 종료가 적용되어 스택이 풀릴 때까지 즉시 OOM abort를 피하도록 한계를 일시 상향
+                current_limit + 16 * 1024 * 1024
+            });
+        }
+
         runtime
             .execute_script("<runtime>".to_string(), RUNTIME_JS.to_string())
             .map_err(|e| ScriptError::RuntimeInit(e.to_string()))?;
 
         Ok(Self {
             runtime,
+            isolate_handle,
             has_on_request: false,
             has_on_response: false,
             has_on_ws_message: false,
             has_on_sse_message: false,
         })
+    }
+
+    /// 다른 스레드에서 이 엔진의 실행을 강제 종료할 수 있는 핸들을 반환한다.
+    pub fn isolate_handle(&self) -> v8::IsolateHandle {
+        self.isolate_handle.clone()
+    }
+
+    /// 외부 terminate_execution으로 인해 현재 실행이 종료 상태인지 확인한다.
+    pub fn is_terminating(&mut self) -> bool {
+        self.runtime.v8_isolate().is_execution_terminating()
+    }
+
+    /// 종료 플래그를 해제한다(엔진을 안전하게 정리/재사용하기 위함).
+    pub fn cancel_termination(&mut self) {
+        self.runtime.v8_isolate().cancel_terminate_execution();
     }
 
     /// 기존 타이머 및 비동기 작업 정리

--- a/crates/scripting/src/handle.rs
+++ b/crates/scripting/src/handle.rs
@@ -60,6 +60,13 @@ const SCRIPT_COMMAND_CHANNEL_CAPACITY: usize = 128;
 /// 빠른 로그 출력 시에도 구독자 lag를 최소화하기 위한 크기.
 const SCRIPT_LOG_CHANNEL_CAPACITY: usize = 256;
 
+/// 엔진 스레드 외부에서 실행 중인 스크립트를 강제 종료하기 위한 제어 채널.
+/// `isolate`는 현재 엔진의 종료 핸들, `terminated`는 강제 종료가 요청되었음을 알리는 플래그다.
+struct EngineControl {
+    isolate: Mutex<Option<v8::IsolateHandle>>,
+    terminated: std::sync::atomic::AtomicBool,
+}
+
 /// 스크립트 엔진에 대한 Send + Sync 핸들 (채널 기반)
 #[derive(Clone)]
 pub struct ScriptHandle {
@@ -68,17 +75,30 @@ pub struct ScriptHandle {
     loaded_path: Arc<std::sync::RwLock<Option<String>>>,
     log_tx: broadcast::Sender<ScriptLogEntry>,
     thread_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+    /// 훅/로드 응답 대기 타임아웃 (기본 SCRIPT_TIMEOUT, 테스트에서 조정 가능)
+    timeout: Duration,
+    control: Arc<EngineControl>,
 }
 
 impl ScriptHandle {
     /// 새 스크립트 핸들 생성 (전용 스레드에서 엔진 실행)
     pub fn new() -> Self {
+        Self::new_with_timeout(SCRIPT_TIMEOUT)
+    }
+
+    /// 타임아웃을 지정하여 핸들 생성 (테스트/특수 용도)
+    pub fn new_with_timeout(timeout: Duration) -> Self {
         let (tx, rx) = mpsc::channel(SCRIPT_COMMAND_CHANNEL_CAPACITY);
         let active = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (log_tx, _) = broadcast::channel(SCRIPT_LOG_CHANNEL_CAPACITY);
+        let control = Arc::new(EngineControl {
+            isolate: Mutex::new(None),
+            terminated: std::sync::atomic::AtomicBool::new(false),
+        });
 
         let active_clone = active.clone();
         let log_tx_clone = log_tx.clone();
+        let control_clone = control.clone();
         let handle = std::thread::spawn(move || {
             let rt = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -90,7 +110,12 @@ impl ScriptHandle {
                     return;
                 }
             };
-            rt.block_on(script_engine_loop(rx, active_clone, log_tx_clone));
+            rt.block_on(script_engine_loop(
+                rx,
+                active_clone,
+                log_tx_clone,
+                control_clone,
+            ));
         });
 
         Self {
@@ -99,6 +124,21 @@ impl ScriptHandle {
             loaded_path: Arc::new(std::sync::RwLock::new(None)),
             log_tx,
             thread_handle: Arc::new(Mutex::new(Some(handle))),
+            timeout,
+            control,
+        }
+    }
+
+    /// 응답 타임아웃 시 호출: 엔진 스레드에서 실행 중인(무한 루프 등) 스크립트를
+    /// V8 terminate_execution으로 강제 중단시켜 엔진 스레드가 다음 명령을 처리할 수 있게 한다.
+    fn terminate_running_script(&self) {
+        self.control
+            .terminated
+            .store(true, std::sync::atomic::Ordering::Release);
+        if let Ok(guard) = self.control.isolate.lock() {
+            if let Some(h) = guard.as_ref() {
+                h.terminate_execution();
+            }
         }
     }
 
@@ -147,10 +187,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        let result = tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("스크립트 로드".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?;
+        let result = match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                return Err(ScriptError::Timeout("스크립트 로드".to_string()));
+            }
+        };
         if result.is_ok() {
             *self.loaded_path.write().unwrap_or_else(|e| e.into_inner()) = Some(path.to_string());
         }
@@ -167,10 +210,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        let result = tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("스크립트 로드".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?;
+        let result = match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                return Err(ScriptError::Timeout("스크립트 로드".to_string()));
+            }
+        };
         if result.is_ok() {
             *self.loaded_path.write().unwrap_or_else(|e| e.into_inner()) = None;
         }
@@ -187,10 +233,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        let result = tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("스크립트 로드".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?;
+        let result = match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                return Err(ScriptError::Timeout("스크립트 로드".to_string()));
+            }
+        };
         if result.is_ok() {
             *self.loaded_path.write().unwrap_or_else(|e| e.into_inner()) = None;
         }
@@ -203,7 +252,9 @@ impl ScriptHandle {
         if let Some(tx) = &self.tx {
             let _ = tx.send(ScriptCommand::Unload { reply: reply_tx }).await;
         }
-        let _ = tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx).await;
+        if tokio::time::timeout(self.timeout, reply_rx).await.is_err() {
+            self.terminate_running_script();
+        }
         *self.loaded_path.write().unwrap_or_else(|e| e.into_inner()) = None;
     }
 
@@ -223,10 +274,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("onRequest".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?
+        match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                Err(ScriptError::Timeout("onRequest".to_string()))
+            }
+        }
     }
 
     /// onResponse 훅 호출
@@ -247,10 +301,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("onResponse".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?
+        match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                Err(ScriptError::Timeout("onResponse".to_string()))
+            }
+        }
     }
 
     /// onWebSocketMessage 훅 호출
@@ -269,10 +326,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("onWebSocketMessage".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?
+        match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                Err(ScriptError::Timeout("onWebSocketMessage".to_string()))
+            }
+        }
     }
 
     /// onSSEMessage 훅 호출
@@ -291,10 +351,13 @@ impl ScriptHandle {
             })
             .await
             .map_err(|_| ScriptError::EngineShutdown)?;
-        tokio::time::timeout(SCRIPT_TIMEOUT, reply_rx)
-            .await
-            .map_err(|_| ScriptError::Timeout("onSSEMessage".to_string()))?
-            .map_err(|_| ScriptError::NoResponse)?
+        match tokio::time::timeout(self.timeout, reply_rx).await {
+            Ok(inner) => inner.map_err(|_| ScriptError::NoResponse)?,
+            Err(_) => {
+                self.terminate_running_script();
+                Err(ScriptError::Timeout("onSSEMessage".to_string()))
+            }
+        }
     }
 }
 
@@ -358,50 +421,103 @@ fn replace_engine(
     }
 }
 
+/// 엔진 제어의 isolate 핸들 슬롯을 갱신한다.
+fn set_isolate(control: &Arc<EngineControl>, handle: Option<v8::IsolateHandle>) {
+    if let Ok(mut g) = control.isolate.lock() {
+        *g = handle;
+    }
+}
+
+/// 기존 엔진을 정리하고 isolate 핸들 슬롯도 비운다.
+fn drop_engine_and_clear(engine: &mut Option<ScriptEngine>, control: &Arc<EngineControl>) {
+    safely_drop_engine(engine);
+    set_isolate(control, None);
+}
+
+/// 새 엔진을 만들고(핸들을 먼저 등록해 로드 중 무한 루프도 종료 가능) 로더를 실행한다.
+fn build_engine<F>(
+    control: &Arc<EngineControl>,
+    log_tx: &broadcast::Sender<ScriptLogEntry>,
+    load: F,
+) -> Result<ScriptEngine, ScriptError>
+where
+    F: FnOnce(&mut ScriptEngine) -> Result<(), ScriptError>,
+{
+    let mut e = ScriptEngine::new()?;
+    // 로드(최상위 코드)에서 무한 루프가 발생해도 외부에서 terminate할 수 있도록 핸들을 먼저 등록
+    set_isolate(control, Some(e.isolate_handle()));
+    let r = load(&mut e);
+    flush_logs(&mut e, log_tx);
+    if control
+        .terminated
+        .swap(false, std::sync::atomic::Ordering::AcqRel)
+    {
+        e.cancel_termination();
+        set_isolate(control, None);
+        return Err(ScriptError::Timeout(
+            "스크립트 로드 중 시간 초과로 강제 종료됨".to_string(),
+        ));
+    }
+    match r {
+        Ok(()) => Ok(e),
+        Err(err) => {
+            set_isolate(control, None);
+            Err(err)
+        }
+    }
+}
+
+/// 강제 종료가 요청된 경우 엔진을 폐기하여 이후 호출이 다시 멈추지 않도록 복구한다.
+fn recover_if_terminated(
+    engine: &mut Option<ScriptEngine>,
+    active: &std::sync::atomic::AtomicBool,
+    control: &Arc<EngineControl>,
+) {
+    if control
+        .terminated
+        .swap(false, std::sync::atomic::Ordering::AcqRel)
+    {
+        if let Some(e) = engine.as_mut() {
+            e.cancel_termination();
+        }
+        drop_engine_and_clear(engine, control);
+        active.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// 전용 스레드에서 실행되는 스크립트 엔진 이벤트 루프
 async fn script_engine_loop(
     mut rx: mpsc::Receiver<ScriptCommand>,
     active: Arc<std::sync::atomic::AtomicBool>,
     log_tx: broadcast::Sender<ScriptLogEntry>,
+    control: Arc<EngineControl>,
 ) {
     let mut engine: Option<ScriptEngine> = None;
 
     while let Some(cmd) = rx.recv().await {
         match cmd {
             ScriptCommand::LoadFile { path, reply } => {
-                safely_drop_engine(&mut engine);
-                let result = ScriptEngine::new().and_then(|mut e| {
-                    e.load_script(&path)?;
-                    flush_logs(&mut e, &log_tx);
-                    Ok(e)
-                });
+                drop_engine_and_clear(&mut engine, &control);
+                let result = build_engine(&control, &log_tx, |e| e.load_script(&path));
                 replace_engine(&mut engine, &active, &log_tx, result, reply);
             }
             ScriptCommand::LoadCode { code, reply } => {
-                safely_drop_engine(&mut engine);
-                let result = ScriptEngine::new().and_then(|mut e| {
-                    e.load_code(&code)?;
-                    flush_logs(&mut e, &log_tx);
-                    Ok(e)
-                });
+                drop_engine_and_clear(&mut engine, &control);
+                let result = build_engine(&control, &log_tx, |e| e.load_code(&code));
                 replace_engine(&mut engine, &active, &log_tx, result, reply);
             }
             ScriptCommand::LoadTsCode { code, reply } => {
-                safely_drop_engine(&mut engine);
-                let result = ScriptEngine::new().and_then(|mut e| {
-                    e.load_ts_code(&code)?;
-                    flush_logs(&mut e, &log_tx);
-                    Ok(e)
-                });
+                drop_engine_and_clear(&mut engine, &control);
+                let result = build_engine(&control, &log_tx, |e| e.load_ts_code(&code));
                 replace_engine(&mut engine, &active, &log_tx, result, reply);
             }
             ScriptCommand::Unload { reply } => {
-                safely_drop_engine(&mut engine);
+                drop_engine_and_clear(&mut engine, &control);
                 active.store(false, std::sync::atomic::Ordering::Release);
                 let _ = reply.send(());
             }
             ScriptCommand::Shutdown => {
-                safely_drop_engine(&mut engine);
+                drop_engine_and_clear(&mut engine, &control);
                 active.store(false, std::sync::atomic::Ordering::Release);
                 break;
             }
@@ -413,6 +529,7 @@ async fn script_engine_loop(
                 } else {
                     Ok(RequestAction::Forward)
                 };
+                recover_if_terminated(&mut engine, &active, &control);
                 let _ = reply.send(result);
             }
             ScriptCommand::InvokeOnResponse {
@@ -427,6 +544,7 @@ async fn script_engine_loop(
                 } else {
                     Ok(ResponseAction::Forward)
                 };
+                recover_if_terminated(&mut engine, &active, &control);
                 let _ = reply.send(result);
             }
             ScriptCommand::InvokeOnWsMessage { message, reply } => {
@@ -437,6 +555,7 @@ async fn script_engine_loop(
                 } else {
                     Ok(WsAction::Forward)
                 };
+                recover_if_terminated(&mut engine, &active, &control);
                 let _ = reply.send(result);
             }
             ScriptCommand::InvokeOnSseEvent { event, reply } => {
@@ -447,8 +566,53 @@ async fn script_engine_loop(
                 } else {
                     Ok(SseAction::Forward)
                 };
+                recover_if_terminated(&mut engine, &active, &control);
                 let _ = reply.send(result);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn dummy_request() -> ScriptRequest {
+        ScriptRequest {
+            method: "GET".to_string(),
+            url: "http://example.com/".to_string(),
+            headers: HashMap::new(),
+            body: None,
+        }
+    }
+
+    /// 무한 루프 훅이 타임아웃으로 강제 종료되고, 엔진 스레드가 복구되어
+    /// 이후 정상 스크립트 로드가 동작하는지 검증한다(영구 행/DoS 방지).
+    #[tokio::test]
+    async fn infinite_loop_hook_terminates_and_engine_recovers() {
+        let handle = ScriptHandle::new_with_timeout(Duration::from_millis(800));
+
+        // onRequest에 무한 루프를 등록(등록 자체는 즉시 완료)
+        handle
+            .load_code("cheolsu.onRequest((req) => { while (true) {} });")
+            .await
+            .expect("무한 루프 훅 로드는 성공해야 함");
+
+        // 훅 호출은 타임아웃되어야 하며 내부적으로 V8 실행을 강제 종료한다
+        let r = handle.invoke_on_request(&dummy_request()).await;
+        assert!(
+            matches!(r, Err(ScriptError::Timeout(_))),
+            "무한 루프 훅은 Timeout이어야 함, got {:?}",
+            r
+        );
+
+        // 엔진 스레드가 복구되어 새 정상 스크립트 로드가 정상 동작해야 함(영구 행 방지)
+        handle
+            .load_code("cheolsu.onRequest((req) => ({ action: 'forward' }));")
+            .await
+            .expect("강제 종료 후 엔진이 복구되어 재로드가 성공해야 함");
+
+        handle.shutdown().await;
     }
 }


### PR DESCRIPTION
검증된 백엔드 High 스크립팅 버그 2건을 수정합니다. (V8 내부 — 안전한 deno_core/v8 API만 사용)

| # | 버그 | 위치 | 수정 |
|---|---|---|---|
|H6|스크립트 타임아웃이 폭주 스크립트를 못 멈춰 엔진 영구 데드락(DoS)|`scripting/handle.rs`|타임아웃 시 `IsolateHandle::terminate_execution()`으로 강제 중단 후 엔진 폐기·복구. 로드/훅 양쪽 적용|
|H7|`heap_limits`만 설정해 메모리 초과 시 프로세스 전체 abort(데몬 크래시)|`scripting/engine/mod.rs`|`add_near_heap_limit_callback`로 한계 근접 시 스크립트 강제 종료|

## 검증
- ✅ `cargo build --workspace`
- ✅ scripting 테스트 20 pass / 0 fail
- ✅ 신규 회귀 테스트: 무한 루프 훅 → 800ms 타임아웃 강제 종료 → 엔진 복구 후 재로드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)