### PR TITLE
데이터 모델 Medium 수정: UTF-8 패닉/손상, HAR Set-Cookie (3건)

### DIFF
--- a/crates/proxy_v2_models/src/graphql.rs
+++ b/crates/proxy_v2_models/src/graphql.rs
@@ -279,29 +279,35 @@ pub fn parse_graphql_request_from_query_params(uri: &str) -> Vec<GraphqlOperatio
 
 /// 간단한 URL 디코딩 (percent-encoding)
 fn urlencoding_decode(input: &str) -> Option<String> {
-    let mut result = String::with_capacity(input.len());
+    // percent-decoding은 바이트 단위로 수행해야 한다. byte를 char로 바로 캐스팅하면
+    // 멀티바이트 UTF-8(예: %C3%A9 = 'é')이 두 개의 Latin-1 문자로 깨진다.
+    let mut bytes: Vec<u8> = Vec::with_capacity(input.len());
     let mut chars = input.chars();
     while let Some(c) = chars.next() {
         if c == '%' {
             let hex: String = chars.by_ref().take(2).collect();
             if hex.len() == 2 {
                 if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                    result.push(byte as char);
+                    bytes.push(byte);
                 } else {
-                    result.push('%');
-                    result.push_str(&hex);
+                    bytes.push(b'%');
+                    bytes.extend_from_slice(hex.as_bytes());
                 }
             } else {
-                result.push('%');
-                result.push_str(&hex);
+                bytes.push(b'%');
+                bytes.extend_from_slice(hex.as_bytes());
             }
         } else if c == '+' {
-            result.push(' ');
+            bytes.push(b' ');
         } else {
-            result.push(c);
+            let mut buf = [0u8; 4];
+            bytes.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
         }
     }
-    Some(result)
+    // 디코딩된 바이트를 UTF-8로 해석(잘못된 시퀀스는 lossy 대체)
+    let decoded = String::from_utf8(bytes)
+        .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned());
+    Some(decoded)
 }
 
 /// 응답 body에서 GraphQL 응답을 파싱

--- a/crates/proxy_v2_models/src/har/helpers.rs
+++ b/crates/proxy_v2_models/src/har/helpers.rs
@@ -27,6 +27,26 @@ pub(super) fn compute_headers_size(headers: &http::HeaderMap) -> i64 {
 }
 
 pub(super) fn parse_cookies(headers: &http::HeaderMap, header_name: &str) -> Vec<HarCookie> {
+    // Set-Cookie(응답)는 헤더 1개당 쿠키 1개이며, '; Path=...; HttpOnly' 등은 속성이다.
+    // 또한 여러 Set-Cookie 헤더가 올 수 있으므로 get_all로 모두 수집한다.
+    // (기존엔 ';'로 분할해 속성을 별도 쿠키로 오인하고, 첫 헤더만 읽어 다중 쿠키를 누락했다)
+    if header_name.eq_ignore_ascii_case("set-cookie") {
+        return headers
+            .get_all(header_name)
+            .iter()
+            .filter_map(|value| {
+                let s = value.to_str().ok()?;
+                let first = s.split(';').next()?.trim();
+                let (name, val) = first.split_once('=')?;
+                Some(HarCookie {
+                    name: name.trim().to_string(),
+                    value: val.trim().to_string(),
+                })
+            })
+            .collect();
+    }
+
+    // 요청 Cookie 헤더: "n1=v1; n2=v2"처럼 여러 쿠키가 ';'로 구분된다.
     let Some(value) = headers.get(header_name) else {
         return Vec::new();
     };

--- a/crates/proxy_v2_models/src/har/tests.rs
+++ b/crates/proxy_v2_models/src/har/tests.rs
@@ -447,3 +447,20 @@ fn parse_cookies_multiple() {
     assert_eq!(cookies[0].name, "a");
     assert_eq!(cookies[2].value, "3");
 }
+
+#[test]
+fn parse_set_cookie_ignores_attributes_and_collects_all() {
+    let mut headers = HeaderMap::new();
+    headers.append(
+        "set-cookie",
+        "sid=abc; Path=/; HttpOnly; Secure".parse().unwrap(),
+    );
+    headers.append("set-cookie", "theme=dark; Max-Age=3600".parse().unwrap());
+    let cookies = helpers::parse_cookies(&headers, "set-cookie");
+    // 헤더 2개 → 쿠키 2개. Path/HttpOnly 등 속성은 쿠키로 취급하지 않는다.
+    assert_eq!(cookies.len(), 2);
+    assert_eq!(cookies[0].name, "sid");
+    assert_eq!(cookies[0].value, "abc");
+    assert_eq!(cookies[1].name, "theme");
+    assert_eq!(cookies[1].value, "dark");
+}

--- a/crates/proxy_v2_models/src/openapi/schema_inference.rs
+++ b/crates/proxy_v2_models/src/openapi/schema_inference.rs
@@ -133,7 +133,12 @@ pub fn merge_schemas(schemas: &[SchemaObject]) -> SchemaObject {
 
 fn truncate_example(s: &str) -> String {
     if s.len() > 100 {
-        format!("{}...", &s[..100])
+        // UTF-8 문자 경계에서 자르기(멀티바이트 경계 슬라이싱 패닉 방지)
+        let mut end = 100;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     } else {
         s.to_string()
     }


### PR DESCRIPTION
검증된 `proxy_v2_models` Medium 버그 3건.

| # | 버그 | 위치 |
|---|---|---|
|M8|OpenAPI 추론 `truncate_example` UTF-8 경계 패닉|`openapi/schema_inference.rs`|
|M9|GraphQL GET 쿼리 percent-decode가 멀티바이트 UTF-8 손상|`graphql.rs`|
|M10|HAR Set-Cookie가 속성을 별도 쿠키로 오인 + 다중 헤더 누락|`har/helpers.rs`|

✅ `cargo test -p proxy_v2_models` 267 pass / 0 fail (신규 set-cookie 회귀 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)