### PR TITLE
ops Medium 수정: SSE UTF-8 패닉/ID 충돌/세션 규칙 동기화 (3건)

### DIFF
--- a/crates/cheolsu_ops/src/id.rs
+++ b/crates/cheolsu_ops/src/id.rs
@@ -6,6 +6,26 @@ static MAPPING_COUNTER: AtomicU32 = AtomicU32::new(0);
 static REVERSE_PROXY_COUNTER: AtomicU32 = AtomicU32::new(0);
 static SERVER_REPLAY_COUNTER: AtomicU32 = AtomicU32::new(0);
 
+/// 외부에서 로드된 ID("{prefix}{n}")를 관찰하여 카운터를 n+1 이상으로 끌어올린다.
+/// (세션/HAR 로드 시 기존 ID와 새 ID가 충돌하는 것을 방지)
+fn observe_counter(counter: &AtomicU32, id: &str, prefix: &str) {
+    let Some(n) = id.strip_prefix(prefix).and_then(|s| s.parse::<u32>().ok()) else {
+        return;
+    };
+    let mut cur = counter.load(Ordering::Relaxed);
+    while n >= cur {
+        match counter.compare_exchange_weak(cur, n + 1, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(actual) => cur = actual,
+        }
+    }
+}
+
+/// 로드된 규칙 ID를 관찰하여 rule 카운터 충돌을 방지한다.
+pub fn observe_rule_id(id: &str) {
+    observe_counter(&RULE_COUNTER, id, "rule_");
+}
+
 pub fn next_rule_id() -> String {
     format!("rule_{}", RULE_COUNTER.fetch_add(1, Ordering::Relaxed))
 }

--- a/crates/cheolsu_ops/src/session.rs
+++ b/crates/cheolsu_ops/src/session.rs
@@ -61,7 +61,7 @@ pub fn save_session(ctx: &OpsContext, p: SaveSessionParams) -> OpResult {
     }
 }
 
-pub fn load_session(ctx: &OpsContext, p: LoadSessionParams) -> OpResult {
+pub async fn load_session(ctx: &OpsContext, p: LoadSessionParams) -> OpResult {
     let file_path = std::path::Path::new(&p.path);
     let is_har = p.path.to_lowercase().ends_with(".har");
 
@@ -95,13 +95,23 @@ pub fn load_session(ctx: &OpsContext, p: LoadSessionParams) -> OpResult {
     ctx.store.transactions.lock().extend(transactions);
     ctx.store.ws_messages.lock().extend(ws_messages);
 
+    let mut rules_changed = false;
     if !rules.is_empty() {
         let mut current_rules = ctx.store.rules.lock();
         for rule in rules {
+            // M12: 로드된 ID를 관찰해 카운터 충돌 방지(이후 새 규칙이 같은 ID를 받지 않도록)
+            crate::id::observe_rule_id(&rule.id);
             if !current_rules.iter().any(|r| r.id == rule.id) {
                 current_rules.push(rule);
+                rules_changed = true;
             }
         }
+    } // rules 락 해제 (send_rules가 내부에서 다시 락하므로 await 전에 반드시 해제)
+
+    // M13: 로드한 인터셉트 규칙을 데몬에 동기화한다(미동기화 시 규칙이 비활성 상태로 남음).
+    // 데몬 미연결 등은 best-effort로 무시한다.
+    if rules_changed {
+        let _ = ctx.send_rules().await;
     }
 
     let mode = if p.append { "appended" } else { "loaded" };

--- a/crates/cheolsu_ops/src/sse.rs
+++ b/crates/cheolsu_ops/src/sse.rs
@@ -20,7 +20,12 @@ pub fn get_sse_events(ctx: &OpsContext, p: GetSseEventsParams) -> OpResult {
         .map(|evt| {
             let event_type = evt.event_type.as_deref().unwrap_or("message").to_string();
             let data = if evt.data.len() > 200 {
-                format!("{}...", &evt.data[..200])
+                // UTF-8 문자 경계에서 자르기(멀티바이트 경계 슬라이싱 패닉 방지)
+                let mut end = 200;
+                while end > 0 && !evt.data.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...", &evt.data[..end])
             } else {
                 evt.data.clone()
             };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1091,13 +1091,16 @@ async fn run(cli: Cli) -> i32 {
                     description: args.description,
                 },
             ),
-            SessionCommands::Load(args) => cheolsu_ops::session::load_session(
-                &ctx,
-                LoadSessionParams {
-                    path: args.path,
-                    append: args.append,
-                },
-            ),
+            SessionCommands::Load(args) => {
+                cheolsu_ops::session::load_session(
+                    &ctx,
+                    LoadSessionParams {
+                        path: args.path,
+                        append: args.append,
+                    },
+                )
+                .await
+            }
         },
 
         // Script

--- a/crates/mcp_server/src/tools/session.rs
+++ b/crates/mcp_server/src/tools/session.rs
@@ -22,6 +22,6 @@ impl CheolsuMcpServer {
         &self,
         Parameters(p): Parameters<LoadSessionParams>,
     ) -> Result<CallToolResult, McpError> {
-        op_result_to_mcp(cheolsu_ops::session::load_session(&self.ops_ctx(), p))
+        op_result_to_mcp(cheolsu_ops::session::load_session(&self.ops_ctx(), p).await)
     }
 }


### PR DESCRIPTION
검증된 `cheolsu_ops` Medium 버그 3건.

| # | 버그 | 위치 |
|---|---|---|
|M11|`get_sse_events` 멀티바이트 UTF-8 경계 패닉|`sse.rs`|
|M12|세션/HAR 로드 후 ID 카운터 미갱신 → 신규 ID 충돌|`id.rs` + `session.rs`|
|M13|`load_session`이 로드한 규칙을 데몬에 미동기화(규칙 비활성)|`session.rs` (async화 + `send_rules`)|

✅ `cargo build/test -p cheolsu_ops -p cheolsu-cli -p cheolsu-proxy-mcp` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)