### PR TITLE
proxy_daemon Medium 수정: curl/SSE/브레이크포인트/시스템프록시/분석 (5건)

### DIFF
--- a/crates/proxy_daemon/src/analytics/performance.rs
+++ b/crates/proxy_daemon/src/analytics/performance.rs
@@ -62,7 +62,8 @@ impl TrafficAnalytics {
             return Vec::new();
         }
 
-        let bucket_ms = (bucket_seconds * 1000) as i64;
+        // bucket_seconds가 0이면 time / bucket_ms에서 0으로 나눗셈 패닉이 발생하므로 최소 1로 클램프
+        let bucket_ms = (bucket_seconds.max(1) * 1000) as i64;
 
         // 타임스탬프 기반으로 버킷에 넣기
         let mut buckets: HashMap<i64, (usize, usize, Vec<u64>)> = HashMap::new();

--- a/crates/proxy_daemon/src/breakpoint_handler.rs
+++ b/crates/proxy_daemon/src/breakpoint_handler.rs
@@ -62,6 +62,8 @@ impl LoggingHandler {
                 }
                 if let Some(body) = new_body {
                     use http_body_util::Full;
+                    // 바디 교체 시 stale content-length/encoding 제거(요청 행/손상 방지)
+                    crate::header_utils::clear_content_encoding_headers(req.headers_mut());
                     *req.body_mut() = Body::from(Full::new(bytes::Bytes::from(body)));
                 }
                 Ok(req)

--- a/crates/proxy_daemon/src/curl_fallback.rs
+++ b/crates/proxy_daemon/src/curl_fallback.rs
@@ -11,7 +11,6 @@ pub async fn fallback_with_curl(
     req: &ProxiedRequest,
 ) -> Result<Response<Body>, Box<dyn std::error::Error>> {
     use std::process::Command;
-    use std::str;
 
     let url = req.uri().to_string();
     let method = req.method().to_string();
@@ -49,45 +48,53 @@ pub async fn fallback_with_curl(
         return Err(format!("curl 실행 실패: {}", output.status).into());
     }
 
-    let response_text = str::from_utf8(&output.stdout)?;
-    debug!("curl 응답 길이: {} bytes", response_text.len());
+    debug!("curl 응답 길이: {} bytes", output.stdout.len());
 
-    parse_curl_response(response_text)
+    parse_curl_response(&output.stdout)
 }
 
-/// curl 응답을 HTTP Response로 파싱하는 함수
-pub fn parse_curl_response(
-    response_text: &str,
-) -> Result<Response<Body>, Box<dyn std::error::Error>> {
-    let lines: Vec<&str> = response_text.lines().collect();
-    if lines.is_empty() {
-        return Err("빈 응답".into());
+/// raw 응답을 헤더 블록과 본문 바이트로 분리한다(\r\n\r\n 우선, 없으면 \n\n).
+fn split_head_body(raw: &[u8]) -> (&[u8], &[u8]) {
+    let find = |needle: &[u8]| raw.windows(needle.len()).position(|w| w == needle);
+    if let Some(pos) = find(b"\r\n\r\n") {
+        (&raw[..pos], &raw[pos + 4..])
+    } else if let Some(pos) = find(b"\n\n") {
+        (&raw[..pos], &raw[pos + 2..])
+    } else {
+        (raw, &[])
     }
+}
 
-    let status_line = lines[0];
+/// curl 응답(raw 바이트)을 HTTP Response로 파싱하는 함수.
+/// 본문은 원본 바이트를 그대로 보존한다(과거엔 `.lines().join("\n")`으로 \r/바이너리가 손상됐다).
+pub fn parse_curl_response(raw: &[u8]) -> Result<Response<Body>, Box<dyn std::error::Error>> {
+    use http_body_util::Full;
+
+    let (header_bytes, body_bytes) = split_head_body(raw);
+    let header_text = String::from_utf8_lossy(header_bytes);
+    let mut lines = header_text.lines();
+
+    let status_line = lines.next().ok_or("빈 응답")?;
     let parts: Vec<&str> = status_line.split_whitespace().collect();
     if parts.len() < 2 {
         return Err("잘못된 상태 라인".into());
     }
-
-    let status_code = parts[1].parse::<u16>()?;
-    let status = StatusCode::from_u16(status_code)?;
-
-    let mut header_end = 0;
-    for (i, line) in lines.iter().enumerate() {
-        if line.is_empty() {
-            header_end = i;
-            break;
-        }
-    }
+    let status = StatusCode::from_u16(parts[1].parse::<u16>()?)?;
 
     let mut headers = HeaderMap::new();
-    for line in &lines[1..header_end] {
+    for line in lines {
+        if line.is_empty() {
+            continue;
+        }
         if let Some(colon_pos) = line.find(':') {
-            let name = &line[..colon_pos].trim();
-            let value = &line[colon_pos + 1..].trim();
+            let name = line[..colon_pos].trim();
+            let value = line[colon_pos + 1..].trim();
 
-            if name.to_lowercase() == "content-length" {
+            // 본문을 원본 바이트 그대로 전달하므로 content-length는 무효(hyper가 재계산),
+            // transfer-encoding(chunked)도 curl이 이미 디코드했으므로 제거한다.
+            // content-encoding은 본문이 아직 인코딩된 상태일 수 있으므로 보존한다.
+            let lower = name.to_ascii_lowercase();
+            if lower == "content-length" || lower == "transfer-encoding" {
                 continue;
             }
 
@@ -99,15 +106,11 @@ pub fn parse_curl_response(
         }
     }
 
-    let body_text = if header_end + 1 < lines.len() {
-        lines[header_end + 1..].join("\n")
-    } else {
-        String::new()
-    };
-
     let mut response = Response::builder()
         .status(status)
-        .body(Body::from(body_text))?;
+        .body(Body::from(Full::new(bytes::Bytes::from(
+            body_bytes.to_vec(),
+        ))))?;
 
     *response.headers_mut() = headers;
 

--- a/crates/proxy_daemon/src/sse_handler.rs
+++ b/crates/proxy_daemon/src/sse_handler.rs
@@ -8,6 +8,27 @@ use tracing::{debug, error};
 
 use crate::handler::LoggingHandler;
 
+/// 누적 버퍼에서 디코딩 가능한 최대 UTF-8 prefix를 String으로 반환하고, 소비한 바이트 수를 돌려준다.
+/// 끝의 불완전한 멀티바이트 시퀀스는 소비하지 않고 남겨, 다음 프레임과 이어붙인다.
+/// 중간에 실제로 잘못된 바이트가 있으면 lossy로 처리하고 소비해 스톨을 방지한다.
+fn decode_sse_prefix(buf: &[u8]) -> (String, usize) {
+    match std::str::from_utf8(buf) {
+        Ok(s) => (s.to_string(), buf.len()),
+        Err(e) => {
+            let valid = e.valid_up_to();
+            match e.error_len() {
+                // 끝에 불완전한 시퀀스 → 유효 prefix만 소비하고 나머지는 다음 프레임 대기
+                None => (String::from_utf8_lossy(&buf[..valid]).into_owned(), valid),
+                // 중간의 잘못된 바이트 → 잘못된 부분까지 lossy로 소비(파서 스톨 방지)
+                Some(bad) => (
+                    String::from_utf8_lossy(&buf[..valid + bad]).into_owned(),
+                    valid + bad,
+                ),
+            }
+        }
+    }
+}
+
 /// SSE 이벤트 (이벤트 또는 연결 상태)
 #[derive(Clone, Debug)]
 pub enum SseEvent {
@@ -73,6 +94,8 @@ impl LoggingHandler {
             let mut body_stream = body;
             let mut collected_chunks = Vec::new();
             let mut sse_parser = SseParser::new();
+            // 프레임 경계에서 분할된 멀티바이트 UTF-8을 이어붙이기 위한 캐리오버 버퍼
+            let mut pending: Vec<u8> = Vec::new();
 
             while let Some(frame_result) = body_stream.frame().await {
                 match frame_result {
@@ -80,9 +103,15 @@ impl LoggingHandler {
                         if let Some(data) = frame.data_ref() {
                             collected_chunks.extend_from_slice(data);
 
-                            // SSE 파서에 청크 전달
-                            if let Ok(chunk_str) = std::str::from_utf8(data) {
-                                let parsed_events = sse_parser.feed(chunk_str);
+                            // SSE 파서에 청크 전달.
+                            // 프레임 경계에서 멀티바이트 UTF-8이 쪼개지면 from_utf8가 실패해
+                            // 해당 바이트가 영구 유실(파서 desync)되므로, 유효 prefix만 디코딩하고
+                            // 불완전한 잔여 바이트는 다음 프레임으로 넘긴다.
+                            pending.extend_from_slice(data);
+                            let (decoded, consumed) = decode_sse_prefix(&pending);
+                            pending.drain(..consumed);
+                            if !decoded.is_empty() {
+                                let parsed_events = sse_parser.feed(&decoded);
                                 for parsed in parsed_events {
                                     // 스크립팅 훅 호출
                                     let sse_msg = scripting::ScriptSseEvent {
@@ -161,5 +190,33 @@ impl LoggingHandler {
         });
 
         response_for_client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_sse_prefix;
+
+    #[test]
+    fn decode_sse_prefix_full_valid() {
+        let (decoded, consumed) = decode_sse_prefix("hello".as_bytes());
+        assert_eq!(decoded, "hello");
+        assert_eq!(consumed, 5);
+    }
+
+    #[test]
+    fn decode_sse_prefix_handles_split_multibyte() {
+        // "한"(U+D55C) = [0xED, 0x95, 0x9C]
+        let full = "ab한".as_bytes().to_vec();
+        // 마지막 멀티바이트의 첫 2바이트만 도착한 상태
+        let (decoded, consumed) = decode_sse_prefix(&full[..full.len() - 1]);
+        assert_eq!(decoded, "ab", "유효 prefix만 디코딩되어야 함");
+        assert_eq!(consumed, 2, "불완전 시퀀스는 소비하지 않고 보존해야 함");
+
+        // 나머지 바이트가 도착하면 완성됨
+        let remaining = &full[consumed..];
+        let (decoded2, consumed2) = decode_sse_prefix(remaining);
+        assert_eq!(decoded2, "한");
+        assert_eq!(consumed2, remaining.len());
     }
 }

--- a/crates/proxy_daemon/src/system_proxy.rs
+++ b/crates/proxy_daemon/src/system_proxy.rs
@@ -1,8 +1,62 @@
 use std::env;
 use std::process::Command;
+use std::sync::Mutex;
 use tracing::info;
 
 use crate::error::DaemonError;
+
+/// 프록시 활성화 직전의 시스템 프록시 설정(해제 시 복원용).
+static PREVIOUS_PROXY: Mutex<Option<PreviousProxy>> = Mutex::new(None);
+
+#[derive(Clone, Default)]
+struct ProxySetting {
+    enabled: bool,
+    server: String,
+    port: String,
+}
+
+#[derive(Clone, Default)]
+struct PreviousProxy {
+    web: ProxySetting,
+    secure: ProxySetting,
+}
+
+/// networksetup -getwebproxy/-getsecurewebproxy 출력에서 현재 프록시 설정을 읽는다.
+fn read_proxy_setting(service: &str, get_kind: &str) -> ProxySetting {
+    let mut s = ProxySetting::default();
+    if let Ok(out) = Command::new("networksetup")
+        .args([get_kind, service])
+        .output()
+    {
+        let text = String::from_utf8_lossy(&out.stdout);
+        for line in text.lines() {
+            if let Some(v) = line.strip_prefix("Enabled: ") {
+                s.enabled = v.trim().eq_ignore_ascii_case("yes");
+            } else if let Some(v) = line.strip_prefix("Server: ") {
+                s.server = v.trim().to_string();
+            } else if let Some(v) = line.strip_prefix("Port: ") {
+                s.port = v.trim().to_string();
+            }
+        }
+    }
+    s
+}
+
+/// 저장된 프록시 설정을 복원한다(활성화돼 있었으면 서버/포트 복원, 아니면 off).
+fn restore_proxy_setting(service: &str, set_kind: &str, state_kind: &str, s: &ProxySetting) {
+    if s.enabled && !s.server.is_empty() {
+        let _ = Command::new("networksetup")
+            .args([set_kind, service, &s.server, &s.port])
+            .status();
+        let _ = Command::new("networksetup")
+            .args([state_kind, service, "on"])
+            .status();
+    } else {
+        let _ = Command::new("networksetup")
+            .args([state_kind, service, "off"])
+            .status();
+    }
+}
 
 /// 현재 활성 네트워크 서비스 이름 가져오기 (macOS)
 pub fn get_active_service() -> Option<String> {
@@ -48,6 +102,17 @@ pub fn set_proxy(enable: bool, port: u16) -> Result<(), DaemonError> {
         if enable {
             let port_str = port.to_string();
 
+            // cheolsu 프록시로 덮어쓰기 전에 기존 설정을 저장(해제 시 복원용).
+            // 이미 cheolsu(127.0.0.1)가 설정된 경우(재활성화)는 자기 자신을 저장하지 않는다.
+            let prev_web = read_proxy_setting(service, "-getwebproxy");
+            let prev_secure = read_proxy_setting(service, "-getsecurewebproxy");
+            if prev_web.server != "127.0.0.1" {
+                *PREVIOUS_PROXY.lock().unwrap_or_else(|e| e.into_inner()) = Some(PreviousProxy {
+                    web: prev_web,
+                    secure: prev_secure,
+                });
+            }
+
             // HTTP 프록시 켜기
             Command::new("networksetup")
                 .args(["-setwebproxy", service, "127.0.0.1", &port_str])
@@ -63,19 +128,36 @@ pub fn set_proxy(enable: bool, port: u16) -> Result<(), DaemonError> {
             info!("프록시 설정 완료 - HTTP, HTTPS 프록시 활성화됨");
             info!("   프록시 주소: 127.0.0.1:{}", port);
         } else {
-            // HTTP 프록시 끄기
-            Command::new("networksetup")
-                .args(["-setwebproxystate", service, "off"])
-                .status()
-                .map_err(DaemonError::Io)?;
+            // 이전 설정이 저장돼 있으면 복원하고, 없으면 off로 둔다.
+            // (과거엔 무조건 off로 만들어 cheolsu 시작 전 사용자가 쓰던 프록시를 잃어버렸다)
+            let prev = PREVIOUS_PROXY
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .take();
+            if let Some(prev) = prev {
+                restore_proxy_setting(service, "-setwebproxy", "-setwebproxystate", &prev.web);
+                restore_proxy_setting(
+                    service,
+                    "-setsecurewebproxy",
+                    "-setsecurewebproxystate",
+                    &prev.secure,
+                );
+                info!("프록시 해제 - 이전 시스템 프록시 설정 복원 완료");
+            } else {
+                // HTTP 프록시 끄기
+                Command::new("networksetup")
+                    .args(["-setwebproxystate", service, "off"])
+                    .status()
+                    .map_err(DaemonError::Io)?;
 
-            // HTTPS 프록시 끄기
-            Command::new("networksetup")
-                .args(["-setsecurewebproxystate", service, "off"])
-                .status()
-                .map_err(DaemonError::Io)?;
+                // HTTPS 프록시 끄기
+                Command::new("networksetup")
+                    .args(["-setsecurewebproxystate", service, "off"])
+                    .status()
+                    .map_err(DaemonError::Io)?;
 
-            info!("프록시 설정 해제 완료 - HTTP, HTTPS 프록시 비활성화됨");
+                info!("프록시 설정 해제 완료 - HTTP, HTTPS 프록시 비활성화됨");
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
검증된 `proxy_daemon` Medium 버그 5건.

| # | 버그 | 위치 |
|---|---|---|
|M3|curl 폴백이 본문을 `\n` 재조합 → 바이너리/CRLF 손상, transfer-encoding 불일치|`curl_fallback.rs` (바이트 단위 재작성)|
|M4|SSE 프레임 경계 UTF-8 분할 시 파서 영구 desync|`sse_handler.rs` (캐리오버 디코딩 + 테스트)|
|M5|브레이크포인트 요청 본문 교체 시 stale content-length|`breakpoint_handler.rs`|
|M6|시스템 프록시 해제 시 이전 설정 미복원(무조건 off)|`system_proxy.rs` (저장/복원)|
|M7|traffic_timeline `bucket_seconds=0` → 0 나눗셈 패닉|`analytics/performance.rs`|

✅ `cargo build/test -p proxy_daemon` 546 pass / 0 fail (신규 SSE 디코딩 테스트 포함)
※ M6(시스템 프록시)은 실제 OS 설정을 변경하므로 헤드리스 런타임 검증은 불가 — 로직/컴파일 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)