### PR TITLE
proxyapi_v2 Medium 수정: Upstream CONNECT over-read, IPv6 SOCKS5 (2건)

### DIFF
--- a/crates/proxyapi_v2/src/socks5/protocol.rs
+++ b/crates/proxyapi_v2/src/socks5/protocol.rs
@@ -94,7 +94,9 @@ impl TargetAddr {
                     segments[6],
                     segments[7],
                 );
-                format!("{}:{}", ipv6, port)
+                // IPv6 리터럴은 RFC 3986/7230 authority-form에서 대괄호로 감싸야 한다
+                // (예: [::1]:443). 비대괄호 형태는 host:port 파싱과 CONNECT 요청을 깨뜨린다.
+                format!("[{}]:{}", ipv6, port)
             }
         }
     }

--- a/crates/proxyapi_v2/src/socks5/tests.rs
+++ b/crates/proxyapi_v2/src/socks5/tests.rs
@@ -47,7 +47,7 @@ mod tests {
         assert_eq!(
             TargetAddr::Ipv6([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 80)
                 .to_address_string(),
-            "::1:80"
+            "[::1]:80"
         );
     }
 
@@ -61,6 +61,6 @@ mod tests {
 
         let addr: SocketAddr = "[::1]:443".parse().unwrap();
         let target = TargetAddr::from_socket_addr(addr);
-        assert_eq!(target.to_address_string(), "::1:443");
+        assert_eq!(target.to_address_string(), "[::1]:443");
     }
 }

--- a/crates/proxyapi_v2/src/upstream_proxy.rs
+++ b/crates/proxyapi_v2/src/upstream_proxy.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::watch;
 use tower::Service;
@@ -105,7 +105,12 @@ pub async fn connect_to_target(
     target: &str,
     upstream: Option<&UpstreamProxyConfig>,
 ) -> Result<TcpStream, UpstreamProxyError> {
-    let host = target.split(':').next().unwrap_or(target);
+    // IPv6 리터럴([::1]:443)과 일반 host:port 모두에서 호스트만 정확히 추출
+    let host = if let Some(rest) = target.strip_prefix('[') {
+        rest.split(']').next().unwrap_or(target)
+    } else {
+        target.rsplit_once(':').map(|(h, _)| h).unwrap_or(target)
+    };
 
     match upstream {
         Some(config) if !config.should_bypass(host) => {
@@ -146,32 +151,39 @@ async fn connect_via_upstream(
 
     connect_req.push_str("\r\n");
 
-    let (reader, mut writer) = stream.into_split();
+    let (mut reader, mut writer) = stream.into_split();
     writer.write_all(connect_req.as_bytes()).await?;
 
-    // BufReader로 응답 헤더를 줄 단위로 읽기
-    let mut buf_reader = BufReader::new(reader);
-    let mut status_line = String::new();
-    buf_reader.read_line(&mut status_line).await?;
-
-    // 나머지 헤더 소비 (\r\n\r\n 까지)
-    let mut header_line = String::new();
+    // CONNECT 응답을 \r\n\r\n까지만 정확히 읽는다.
+    // BufReader는 read-ahead로 \r\n\r\n 이후(터널 선두 — TLS ServerHello 등) 바이트까지
+    // 버퍼링해 into_inner 시 유실시키므로 사용하지 않는다. 응답은 헤더뿐이라 바이트 단위로 읽는다.
+    let mut response: Vec<u8> = Vec::with_capacity(256);
+    let mut byte = [0u8; 1];
     loop {
-        header_line.clear();
-        let n = buf_reader.read_line(&mut header_line).await?;
-        if n == 0 || header_line == "\r\n" {
+        let n = reader.read(&mut byte).await?;
+        if n == 0 {
+            break; // EOF (불완전 응답)
+        }
+        response.push(byte[0]);
+        if response.ends_with(b"\r\n\r\n") {
             break;
+        }
+        if response.len() > 16 * 1024 {
+            return Err(UpstreamProxyError::ConnectTunnel(
+                "CONNECT 응답 헤더가 너무 큼".to_string(),
+            ));
         }
     }
 
+    let response_str = String::from_utf8_lossy(&response);
+    let status_line = response_str.lines().next().unwrap_or("");
     if !status_line.contains(" 200 ") {
         return Err(UpstreamProxyError::ConnectTunnel(
             status_line.trim().to_string(),
         ));
     }
 
-    // BufReader의 내부 버퍼에 남은 데이터가 없으므로 stream을 재조립
-    let reader = buf_reader.into_inner();
+    // over-read 없이 읽었으므로 터널 선두 바이트 손실 없이 재조립
     let stream = reader.reunite(writer)?;
 
     debug!(target, "Upstream proxy CONNECT 터널 수립 완료");


### PR DESCRIPTION
검증된 `proxyapi_v2` Medium 버그 2건.

| # | 버그 | 위치 |
|---|---|---|
|M1|Upstream CONNECT 응답을 BufReader로 읽어 터널 선두 바이트 유실|`upstream_proxy.rs`|
|M2|IPv6 SOCKS5 대상 주소 대괄호 누락 → 업스트림 CONNECT/host 추출 깨짐|`socks5/protocol.rs` + `upstream_proxy.rs`|

✅ `cargo test -p proxyapi_v2 --features full` 258 pass / 0 fail (IPv6 테스트 기대값 갱신 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)