### PR TITLE
프론트엔드 Medium 수정: cURL/취소가드/누수/필터/동기화/Waterfall (8건)

### DIFF
--- a/desktop/src/app/hooks/useDaemonSyncListeners.ts
+++ b/desktop/src/app/hooks/useDaemonSyncListeners.ts
@@ -42,14 +42,13 @@ export function useDaemonSyncListeners() {
     const unlisten = listen<InterceptRule[]>("intercept_rules_updated", (event) => {
       const rules = event.payload;
       updateDaemonRules(rules);
-      const interceptRules = rules.filter(
-        (r) =>
-          r.action.type === "block" ||
-          r.action.type === "modify_request" ||
-          r.action.type === "modify_response",
-      );
       const mapRules = rules.filter(
         (r) => r.action.type === "map_local" || r.action.type === "map_remote",
+      );
+      // map 규칙을 제외한 모든 규칙(block/modify/rewrite/throttle 등)은 intercept로 분류한다.
+      // (과거엔 화이트리스트에서 rewrite/throttle이 빠져 브로드캐스트 시 GUI에서 소실됐다)
+      const interceptRules = rules.filter(
+        (r) => r.action.type !== "map_local" && r.action.type !== "map_remote",
       );
       setInterceptRules(interceptRules);
       setMapRules(mapRules);

--- a/desktop/src/features/query-filter-editor/lib/query-serializer.ts
+++ b/desktop/src/features/query-filter-editor/lib/query-serializer.ts
@@ -31,12 +31,18 @@ export function createEmptyCondition(): FilterCondition {
 /**
  * BuilderState → 쿼리 문자열
  */
+// 파서가 콤마를 구분자로 split하므로, 값 내부 콤마를 \,로 escape해야 round-trip이 깨지지 않는다.
+// (백슬래시/따옴표는 기존 동작 유지를 위해 건드리지 않는다 — 정규식 패턴 \d 등 보존)
+function escapeFilterValue(v: string): string {
+  return v.replace(/,/g, "\\,");
+}
+
 export function serializeBuilderState(state: BuilderState): string {
   const activeParts: { query: string; logicalOperator: "and" | "or" }[] = [];
 
   for (const condition of state.conditions) {
     if (condition.values.length === 0) continue;
-    const valueStr = condition.values.join(",");
+    const valueStr = condition.values.map(escapeFilterValue).join(",");
     activeParts.push({
       query: `${condition.field}${condition.operator}"${valueStr}"`,
       logicalOperator: condition.logicalOperator,

--- a/desktop/src/features/transaction-details/hooks/use-replay-form.ts
+++ b/desktop/src/features/transaction-details/hooks/use-replay-form.ts
@@ -98,7 +98,8 @@ export function useReplayForm({ transaction, open }: UseReplayFormOptions) {
       if (!openRef.current) return;
       setError(typeof e === "string" ? e : e instanceof Error ? e.message : t`Request failed`);
     } finally {
-      if (openRef.current) setLoading(false);
+      // 요청 중 다이얼로그를 닫아도 loading은 반드시 해제해야 재오픈 시 버튼이 고착되지 않는다
+      setLoading(false);
     }
   }, [method, url, headers, body, t]);
 

--- a/desktop/src/features/transaction-details/ui/binary-preview.tsx
+++ b/desktop/src/features/transaction-details/ui/binary-preview.tsx
@@ -117,20 +117,26 @@ export const BinaryPreview = ({
   useEffect(() => {
     if (!showPdf || dataType !== "Document") return;
 
+    // cleanup이 실제 생성된 URL을 해제하도록 로컬 변수에 보관한다.
+    // (state의 pdfUrl을 cleanup에서 참조하면 stale 값이라 누수가 발생)
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
     const createPdfUrl = async () => {
       const loaded = await loadFileData();
-      if (!loaded) return;
+      if (!loaded || cancelled) return;
       const blob = new Blob([loaded.buffer as ArrayBuffer], {
         type: "application/pdf",
       });
-      const url = URL.createObjectURL(blob);
-      setPdfUrl(url);
+      objectUrl = URL.createObjectURL(blob);
+      setPdfUrl(objectUrl);
     };
 
     createPdfUrl();
 
     return () => {
-      if (pdfUrl) URL.revokeObjectURL(pdfUrl);
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [showPdf]);
 

--- a/desktop/src/hooks/use-body-file.ts
+++ b/desktop/src/hooks/use-body-file.ts
@@ -27,6 +27,9 @@ export function useBodyFile(
       return;
     }
 
+    // filePath가 바뀌면 이전 비동기 읽기 결과를 무시(stale body 표시 방지)
+    let cancelled = false;
+
     const loadBody = async () => {
       setLoading(true);
       setError(null);
@@ -39,16 +42,22 @@ export function useBodyFile(
         const rawData = await readFile(appCachePath, {
           baseDir: BaseDirectory.AppCache,
         });
+        if (cancelled) return;
         setBody(rawData);
       } catch (err) {
+        if (cancelled) return;
         setError(err instanceof Error ? err.message : "파일 읽기 실패");
         setBody(null);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     loadBody();
+
+    return () => {
+      cancelled = true;
+    };
   }, [filePath, enabled]);
 
   return { body, loading, error };

--- a/desktop/src/pages/network-dashboard/lib/utils.ts
+++ b/desktop/src/pages/network-dashboard/lib/utils.ts
@@ -165,6 +165,14 @@ export const getFilteredTransactions = (
     );
 
     if (operator === "or") {
+      // 제외(exclude) 필터는 OR 모드에서도 항상 AND로 적용되어야 한다.
+      // (과거엔 다른 차원의 include가 매칭되면 exclude가 무시되어 제외 대상이 표시됐다)
+      const notExcluded =
+        matchesStatusFilter(status, [], excludeStatus) &&
+        matchesMethodFilter(method, [], excludeMethods) &&
+        matchesPathFilter(path, [], excludeUrls) &&
+        matchesClientFilter(clientAddr, proxyAuthUser, [], excludeClients, clientTags);
+
       const hasIncludeFilter =
         statusFilter.length > 0 ||
         methodFilter.length > 0 ||
@@ -172,16 +180,17 @@ export const getFilteredTransactions = (
         clientFilters.length > 0;
 
       if (!hasIncludeFilter) {
-        return statusMatch && methodMatch && pathMatch && clientMatch;
+        return notExcluded;
       }
 
       const includeMatch =
-        (statusFilter.length > 0 && statusMatch) ||
-        (methodFilter.length > 0 && methodMatch) ||
-        (pathFilters.length > 0 && pathMatch) ||
-        (clientFilters.length > 0 && clientMatch);
+        (statusFilter.length > 0 && matchesStatusFilter(status, statusFilter, [])) ||
+        (methodFilter.length > 0 && matchesMethodFilter(method, methodFilter, [])) ||
+        (pathFilters.length > 0 && matchesPathFilter(path, pathFilters, [])) ||
+        (clientFilters.length > 0 &&
+          matchesClientFilter(clientAddr, proxyAuthUser, clientFilters, [], clientTags));
 
-      return includeMatch;
+      return notExcluded && includeMatch;
     }
 
     return statusMatch && methodMatch && pathMatch && clientMatch;

--- a/desktop/src/shared/lib/curl.ts
+++ b/desktop/src/shared/lib/curl.ts
@@ -26,7 +26,8 @@ export const generateCurlCommand = (transaction: HttpTransaction): string => {
     const uint8Array = body instanceof Uint8Array ? body : new Uint8Array(body);
     const bodyText = decoder.decode(uint8Array);
     if (bodyText.trim()) {
-      curlCommand += ` \\\n  -d '${bodyText.replace(/'/g, "\\'")}'`;
+      // 단일 따옴표 문자열에서는 \' 이스케이프가 동작하지 않으므로 '\'' 방식을 사용해야 한다
+      curlCommand += ` \\\n  -d '${escapeSingleQuote(bodyText)}'`;
     }
   }
 

--- a/desktop/src/shared/lib/query-parser.ts
+++ b/desktop/src/shared/lib/query-parser.ts
@@ -31,6 +31,35 @@ export interface ParsedQuery {
  * - or : 논리 OR (하나라도 만족)
  * - and : 논리 AND (모두 만족, 기본값)
  */
+/**
+ * 이스케이프되지 않은 콤마(,)로 값을 분리하고, 각 조각의 이스케이프(\, \" \' \` \\)를 해제한다.
+ * 값 안에 콤마가 포함돼도(예: URL의 쿼리 파라미터) 여러 조건으로 잘못 분해되지 않는다.
+ */
+function splitEscapedValues(raw: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === "\\" && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      // 알려진 이스케이프(\, \" \' \` \\)만 해제하고, 그 외(\d 등 정규식)는 백슬래시를 보존한다
+      if (next === "," || next === '"' || next === "'" || next === "`" || next === "\\") {
+        current += next;
+      } else {
+        current += ch + next;
+      }
+      i += 1;
+    } else if (ch === ",") {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
 export function parseFilterQuery(query: string): ParsedQuery {
   const result: ParsedQuery = {
     methods: [],
@@ -60,17 +89,14 @@ export function parseFilterQuery(query: string): ParsedQuery {
     const [, key, operator] = match;
     // 3개 캡처 그룹 중 매칭된 것 사용
     const rawValue = match[3] ?? match[4] ?? match[5] ?? "";
-    // 이스케이프 처리: \", \', \`, \\ → 원래 문자로
-    const value = rawValue.replace(/\\(["'`\\])/g, "$1");
+    // 이스케이프되지 않은 콤마로 값을 분리하고 각 조각의 이스케이프를 해제한다(값 내부 콤마 보존)
+    const values = splitEscapedValues(rawValue);
     const isExclude = operator === "!=";
 
     switch (key.toLowerCase()) {
       case "method":
       case "methods": {
-        const methods = value
-          .split(",")
-          .map((m) => m.trim().toUpperCase())
-          .filter(Boolean);
+        const methods = values.map((m) => m.trim().toUpperCase()).filter(Boolean);
 
         if (isExclude) {
           result.excludeMethods.push(...methods);
@@ -81,10 +107,7 @@ export function parseFilterQuery(query: string): ParsedQuery {
       }
 
       case "status": {
-        const statuses = value
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
+        const statuses = values.map((s) => s.trim()).filter(Boolean);
 
         if (isExclude) {
           result.excludeStatus.push(...statuses);
@@ -96,10 +119,7 @@ export function parseFilterQuery(query: string): ParsedQuery {
 
       case "url": {
         // 콤마로 구분된 여러 URL 조건 지원
-        const urlParts = value
-          .split(",")
-          .map((u) => u.trim())
-          .filter(Boolean);
+        const urlParts = values.map((u) => u.trim()).filter(Boolean);
 
         if (isExclude) {
           result.excludeUrls.push(...urlParts);
@@ -110,10 +130,7 @@ export function parseFilterQuery(query: string): ParsedQuery {
       }
 
       case "client": {
-        const clientParts = value
-          .split(",")
-          .map((c) => c.trim())
-          .filter(Boolean);
+        const clientParts = values.map((c) => c.trim()).filter(Boolean);
 
         if (isExclude) {
           result.excludeClients.push(...clientParts);

--- a/desktop/src/widgets/network-table/hooks/use-table-data.ts
+++ b/desktop/src/widgets/network-table/hooks/use-table-data.ts
@@ -5,12 +5,39 @@ import type { HttpTransaction } from "@/entities/proxy";
 import { getAuthority } from "../lib";
 import type { TableRowData } from "../model";
 
+/** 트랜잭션 집합에 대한 Waterfall 시간축 범위를 계산한다. */
+export function computeTimelineRange(transactions: HttpTransaction[]): {
+  start: number;
+  end: number;
+} {
+  let minStart = Infinity;
+  let maxEnd = -Infinity;
+  for (const transaction of transactions) {
+    const reqTime = transaction.request?.time;
+    const resTime = transaction.response?.time;
+    if (reqTime != null && reqTime < minStart) minStart = reqTime;
+    if (resTime != null && resTime > maxEnd) maxEnd = resTime;
+    // 응답이 없으면 요청 시각을 끝으로 간주
+    if (reqTime != null && resTime == null && reqTime > maxEnd) maxEnd = reqTime;
+  }
+  if (!isFinite(minStart)) return { start: 0, end: 0 };
+  // 최소 범위 100ms (너무 짧으면 바가 안 보임)
+  if (maxEnd - minStart < 100_000_000) maxEnd = minStart + 100_000_000;
+  return { start: minStart, end: maxEnd };
+}
+
 interface UseTableDataProps {
   transactions: HttpTransaction[];
   selectedTransaction: HttpTransaction | null;
+  /** 공유 Waterfall 시간축. 지정하지 않으면 transactions로 자체 계산한다. */
+  timelineRange?: { start: number; end: number };
 }
 
-export const useTableData = ({ transactions, selectedTransaction }: UseTableDataProps) => {
+export const useTableData = ({
+  transactions,
+  selectedTransaction,
+  timelineRange,
+}: UseTableDataProps) => {
   const selectedTime = useMemo(
     () => selectedTransaction?.request?.time,
     [selectedTransaction?.request?.time],
@@ -54,25 +81,12 @@ export const useTableData = ({ transactions, selectedTransaction }: UseTableData
     });
   }, [transactions]);
 
-  // Waterfall 시간축 범위 계산
+  // Waterfall 시간축 범위. 공유 범위가 주어지면 그것을 사용(pinned/unpinned가 동일 축을 쓰도록),
+  // 없으면 자체 계산한다.
   const { timelineStart, timelineEnd } = useMemo(() => {
-    let minStart = Infinity;
-    let maxEnd = -Infinity;
-
-    for (const { transaction } of processedTransactions) {
-      const reqTime = transaction.request?.time;
-      const resTime = transaction.response?.time;
-      if (reqTime != null && reqTime < minStart) minStart = reqTime;
-      if (resTime != null && resTime > maxEnd) maxEnd = resTime;
-      // 응답이 없으면 요청 시각을 끝으로 간주
-      if (reqTime != null && resTime == null && reqTime > maxEnd) maxEnd = reqTime;
-    }
-
-    if (!isFinite(minStart)) return { timelineStart: 0, timelineEnd: 0 };
-    // 최소 범위 100ms (너무 짧으면 바가 안 보임)
-    if (maxEnd - minStart < 100_000_000) maxEnd = minStart + 100_000_000;
-    return { timelineStart: minStart, timelineEnd: maxEnd };
-  }, [processedTransactions]);
+    const range = timelineRange ?? computeTimelineRange(transactions);
+    return { timelineStart: range.start, timelineEnd: range.end };
+  }, [transactions, timelineRange]);
 
   const tableData = useMemo<TableRowData[]>(() => {
     return processedTransactions.map((item) => ({

--- a/desktop/src/widgets/network-table/ui/network-table.tsx
+++ b/desktop/src/widgets/network-table/ui/network-table.tsx
@@ -11,7 +11,7 @@ import type { HttpTransaction } from "@/entities/proxy";
 
 import { TableHeader } from "./table-header";
 import { TableBody } from "./table-body";
-import { useTableData } from "../hooks";
+import { useTableData, computeTimelineRange } from "../hooks";
 import { type ColumnKey, columns } from "../model";
 import { useAppSettingsStore } from "@/shared/stores/app-settings-store";
 import { Pin } from "lucide-react";
@@ -87,14 +87,19 @@ export const NetworkTable = ({
     return { pinnedTransactions: pinned, unpinnedTransactions: unpinned };
   }, [transactions, pinnedTransactionIds]);
 
+  // pinned/unpinned가 동일한 Waterfall 시간축을 쓰도록 전체 트랜잭션 기준으로 한 번만 계산해 공유한다.
+  const timelineRange = useMemo(() => computeTimelineRange(transactions), [transactions]);
+
   const { tableData: pinnedTableData } = useTableData({
     transactions: pinnedTransactions,
     selectedTransaction,
+    timelineRange,
   });
 
   const { tableData: unpinnedTableData } = useTableData({
     transactions: unpinnedTransactions,
     selectedTransaction,
+    timelineRange,
   });
 
   // TanStack Table 인스턴스 (unpinned 데이터에 대해 정렬 적용)

--- a/desktop/test/lib/code-export.test.ts
+++ b/desktop/test/lib/code-export.test.ts
@@ -88,7 +88,8 @@ describe("generateCurlCommand", () => {
         data_type: "Text",
       }),
     );
-    expect(result).toContain("it\\'s a test");
+    // 단일 따옴표 문자열에서는 '\'' 방식으로 이스케이프해야 셸에서 올바르게 동작한다
+    expect(result).toContain("it'\\''s a test");
   });
 });
 

--- a/desktop/test/lib/query-serializer.test.ts
+++ b/desktop/test/lib/query-serializer.test.ts
@@ -537,11 +537,12 @@ describe("엣지 케이스", () => {
     expect(serializeBuilderState(state)).toBe('url|="/users/\\d+"');
   });
 
-  test("URL 값에 콤마가 포함된 경우 그대로 직렬화", () => {
+  test("URL 단일 값에 콤마가 포함되면 \\,로 이스케이프된다", () => {
     const state: BuilderState = {
       conditions: [cond({ field: "url", operator: "|=", values: ["api,cdn"] })],
     };
-    expect(serializeBuilderState(state)).toBe('url|="api,cdn"');
+    // 콤마가 포함된 "단일 값"이므로 구분자와 구별되도록 \,로 이스케이프되어야 한다
+    expect(serializeBuilderState(state)).toBe('url|="api\\,cdn"');
   });
 
   test("status 값이 와일드카드 패턴 (2xx, 3xx 등)", () => {
@@ -571,5 +572,15 @@ describe("엣지 케이스", () => {
     const state = parsedQueryToBuilderState(parsed);
     // BuilderState에는 conditions만 있어야 함
     expect(Object.keys(state)).toEqual(["conditions"]);
+  });
+
+  test("콤마가 포함된 단일 값이 round-trip에서 분해되지 않음", () => {
+    const state: BuilderState = {
+      conditions: [cond({ field: "url", operator: "|=", values: ["https://a.com/?x=1,2"] })],
+    };
+    const query = serializeBuilderState(state);
+    const parsed = parseFilterQuery(query);
+    // 콤마가 있어도 단일 URL 값으로 복원되어야 함
+    expect(parsed.urls).toEqual(["https://a.com/?x=1,2"]);
   });
 });


### PR DESCRIPTION
검증된 프론트엔드 Medium 버그 8건.

| # | 버그 | 위치 |
|---|---|---|
|M-fe1|cURL `-d` 바디 작은따옴표 이스케이프 깨짐|`shared/lib/curl.ts`|
|M-fe2|useBodyFile 비동기 읽기 취소 가드 부재(stale body)|`hooks/use-body-file.ts`|
|M-fe3|useReplayForm 진행 중 닫으면 loading 영구 true|`features/transaction-details/hooks/use-replay-form.ts`|
|M-fe4|BinaryPreview PDF blob URL 미해제 누수|`features/transaction-details/ui/binary-preview.tsx`|
|M-fe5|쿼리 빌더 콤마 포함 단일 값 round-trip 분해|`query-serializer.ts` + `query-parser.ts`|
|M-fe6|OR 필터 모드에서 exclude 무시|`pages/network-dashboard/lib/utils.ts`|
|M-fe7|데몬 브로드캐스트 시 rewrite/throttle 규칙 소실|`app/hooks/useDaemonSyncListeners.ts`|
|M-fe8|Waterfall 시간축 pinned/unpinned 분리 계산 왜곡|`widgets/network-table/...`|

## 검증
- ✅ oxfmt/oxlint(에러 없음) / vite build
- ✅ 단위 테스트 584 pass / 0 fail (콤마 round-trip 신규 + 버그-검증 테스트 2건 올바른 동작으로 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)