### PR TITLE
proxy_daemon Low 수정: 블로킹IO/누수/WS/gRPC (6건)

### DIFF
--- a/crates/proxy_daemon/src/client_handler/commands.rs
+++ b/crates/proxy_daemon/src/client_handler/commands.rs
@@ -17,6 +17,8 @@ pub(super) struct CommandState {
     pub(super) shared: SharedDaemonState,
     pub(super) subscribed: Arc<std::sync::atomic::AtomicBool>,
     pub(super) watched_path: Arc<Mutex<Option<String>>>,
+    /// 현재 실행 중인 파일 감시 태스크 핸들(클라이언트 종료/스크립트 교체 시 abort용)
+    pub(super) watcher_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl CommandState {
@@ -219,15 +221,21 @@ pub(super) async fn handle_command(cmd: ClientCommand, ctx: &CommandState) -> bo
                     info!("Script loaded successfully");
                     // 파일 감시 시작
                     if let Some(file_path) = &path {
-                        let mut wp = ctx.watched_path.lock().await;
-                        *wp = Some(file_path.clone());
-                        start_file_watcher(
+                        {
+                            let mut wp = ctx.watched_path.lock().await;
+                            *wp = Some(file_path.clone());
+                        }
+                        let new_handle = start_file_watcher(
                             file_path.clone(),
                             s.script_handle.clone(),
                             ctx.writer.clone(),
                             ctx.watched_path.clone(),
                             s.event_tx.clone(),
                         );
+                        // 이전 감시 태스크를 정리해 태스크/소켓 FD 누수를 방지한다.
+                        if let Some(old) = ctx.watcher_handle.lock().await.replace(new_handle) {
+                            old.abort();
+                        }
                     }
                     // 스크립트 상태 브로드캐스트
                     s.broadcast_event(&DaemonMessage::ScriptStatus {

--- a/crates/proxy_daemon/src/client_handler/mod.rs
+++ b/crates/proxy_daemon/src/client_handler/mod.rs
@@ -169,6 +169,8 @@ pub(crate) async fn handle_client(stream: UnixStream, ctx: ClientHandlerContext)
 
     // 파일 감시 태스크 (스크립트 파일 변경 시 자동 리로드)
     let watched_path: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let watcher_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>> =
+        Arc::new(Mutex::new(None));
 
     let writer_events = writer.clone();
     let subscribed = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -260,6 +262,7 @@ pub(crate) async fn handle_client(stream: UnixStream, ctx: ClientHandlerContext)
         shared,
         subscribed,
         watched_path,
+        watcher_handle: watcher_handle.clone(),
     };
 
     let mut line_buf = String::new();
@@ -295,4 +298,10 @@ pub(crate) async fn handle_client(stream: UnixStream, ctx: ClientHandlerContext)
     // abort()로 안전하게 종료 가능 (상태 변경 없음)
     event_task.abort();
     log_task.abort();
+
+    // 클라이언트 종료 시 파일 감시 태스크도 정리해 태스크/소켓 FD 누수를 방지한다.
+    let pending_watcher = watcher_handle.lock().await.take();
+    if let Some(h) = pending_watcher {
+        h.abort();
+    }
 }

--- a/crates/proxy_daemon/src/client_handler/watcher.rs
+++ b/crates/proxy_daemon/src/client_handler/watcher.rs
@@ -12,7 +12,7 @@ pub(super) fn start_file_watcher(
     writer: Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
     watched_path: Arc<Mutex<Option<String>>>,
     event_tx: broadcast::Sender<String>,
-) {
+) -> tokio::task::JoinHandle<()> {
     use notify::{EventKind, RecursiveMode, Watcher};
 
     tokio::spawn(async move {
@@ -97,5 +97,5 @@ pub(super) fn start_file_watcher(
         }
 
         info!("[Script] File watcher stopped: {}", path);
-    });
+    })
 }

--- a/crates/proxy_daemon/src/intercept/actions.rs
+++ b/crates/proxy_daemon/src/intercept/actions.rs
@@ -112,7 +112,7 @@ impl LoggingHandler {
     }
 
     /// MapLocal 액션 처리 → 로컬 파일 응답 반환
-    pub(crate) fn apply_map_local(
+    pub(crate) async fn apply_map_local(
         file_path: &str,
         status_code: u16,
         headers: &std::collections::HashMap<String, String>,
@@ -124,7 +124,7 @@ impl LoggingHandler {
             "[Intercept] Map Local: {} {} -> {} (규칙: {})",
             method, url, file_path, rule_name
         );
-        let file_bytes = match std::fs::read(file_path) {
+        let file_bytes = match tokio::fs::read(file_path).await {
             Ok(bytes) => Bytes::from(bytes),
             Err(e) => {
                 error!(
@@ -297,6 +297,7 @@ impl LoggingHandler {
                         url,
                         &rule.name,
                     )
+                    .await
                     .into();
                 }
                 InterceptAction::MapRemote {

--- a/crates/proxy_daemon/src/intercept/tests/apply_actions.rs
+++ b/crates/proxy_daemon/src/intercept/tests/apply_actions.rs
@@ -79,8 +79,8 @@ fn test_apply_block_invalid_status_falls_back_to_403() {
 
 // --- apply_map_local 테스트 ---
 
-#[test]
-fn test_apply_map_local_missing_file_returns_404() {
+#[tokio::test]
+async fn test_apply_map_local_missing_file_returns_404() {
     let headers = std::collections::HashMap::new();
     let response = LoggingHandler::apply_map_local(
         "/nonexistent/path/file.json",
@@ -89,7 +89,8 @@ fn test_apply_map_local_missing_file_returns_404() {
         "GET",
         "https://example.com/api",
         "map-local-test",
-    );
+    )
+    .await;
     assert_eq!(response.status().as_u16(), 404);
     assert!(response
         .headers()
@@ -97,8 +98,8 @@ fn test_apply_map_local_missing_file_returns_404() {
         .is_some());
 }
 
-#[test]
-fn test_apply_map_local_with_existing_file() {
+#[tokio::test]
+async fn test_apply_map_local_with_existing_file() {
     use std::io::Write;
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("mock.json");
@@ -113,7 +114,8 @@ fn test_apply_map_local_with_existing_file() {
         "GET",
         "https://example.com/api",
         "map-local-test",
-    );
+    )
+    .await;
     assert_eq!(response.status().as_u16(), 200);
     assert_eq!(
         response
@@ -127,8 +129,8 @@ fn test_apply_map_local_with_existing_file() {
     assert!(response.headers().get("x-cheolsu-map-local").is_some());
 }
 
-#[test]
-fn test_apply_map_local_custom_content_type() {
+#[tokio::test]
+async fn test_apply_map_local_custom_content_type() {
     use std::io::Write;
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("data.bin");
@@ -144,7 +146,8 @@ fn test_apply_map_local_custom_content_type() {
         "POST",
         "https://example.com/upload",
         "map-local-custom",
-    );
+    )
+    .await;
     assert_eq!(response.status().as_u16(), 201);
     assert_eq!(
         response

--- a/crates/proxy_daemon/src/proto_registry.rs
+++ b/crates/proxy_daemon/src/proto_registry.rs
@@ -117,19 +117,32 @@ impl ProtoRegistry {
             .await?;
 
         // gRPC 프레이밍: 1바이트 compressed flag + 4바이트 BE length + message
-        let payload = if data.len() >= 5 {
-            let _compressed = data[0];
+        // compressed flag가 1이면 메시지가 (보통 gzip으로) 압축돼 있으므로 해제 후 디코딩한다.
+        const MAX_GRPC_DECOMPRESSED: u64 = 64 * 1024 * 1024;
+        let payload: std::borrow::Cow<[u8]> = if data.len() >= 5 {
+            let compressed = data[0];
             let len = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
-            if data.len() >= 5 + len {
-                &data[5..5 + len]
+            let complete = data.len() >= 5 + len;
+            let frame: &[u8] = if complete { &data[5..5 + len] } else { data };
+            if compressed == 1 && complete {
+                use flate2::read::GzDecoder;
+                use std::io::Read;
+                let mut out = Vec::new();
+                match GzDecoder::new(frame)
+                    .take(MAX_GRPC_DECOMPRESSED)
+                    .read_to_end(&mut out)
+                {
+                    Ok(_) => std::borrow::Cow::Owned(out),
+                    Err(_) => std::borrow::Cow::Borrowed(frame),
+                }
             } else {
-                data
+                std::borrow::Cow::Borrowed(frame)
             }
         } else {
-            data
+            std::borrow::Cow::Borrowed(data)
         };
 
-        let msg = DynamicMessage::decode(desc, payload).ok()?;
+        let msg = DynamicMessage::decode(desc, payload.as_ref()).ok()?;
 
         let serializer = serde_json::Serializer::new(Vec::new());
         let mut serializer = serializer;

--- a/crates/proxy_daemon/src/ws_handler/handler.rs
+++ b/crates/proxy_daemon/src/ws_handler/handler.rs
@@ -94,16 +94,18 @@ impl LoggingHandler {
                 payload: new_payload,
                 is_binary: new_is_binary,
             }) => {
-                let new_msg = if new_is_binary {
+                // base64 디코드 실패 시 Text로 폴백하면 is_binary도 false로 정정해야
+                // 프레임 타입과 이벤트 메타데이터가 일치한다.
+                let (new_msg, actual_is_binary) = if new_is_binary {
                     use base64::Engine;
                     match base64::engine::general_purpose::STANDARD.decode(&new_payload) {
-                        Ok(data) => Message::Binary(data.into()),
-                        Err(_) => Message::Text(new_payload.clone().into()),
+                        Ok(data) => (Message::Binary(data.into()), true),
+                        Err(_) => (Message::Text(new_payload.clone().into()), false),
                     }
                 } else {
-                    Message::Text(new_payload.clone().into())
+                    (Message::Text(new_payload.clone().into()), false)
                 };
-                Some((new_msg, new_payload, new_is_binary))
+                Some((new_msg, new_payload, actual_is_binary))
             }
             Ok(scripting::WsAction::Drop) => None,
             Err(e) => {

--- a/crates/proxy_daemon/src/ws_handler/trait_impl.rs
+++ b/crates/proxy_daemon/src/ws_handler/trait_impl.rs
@@ -26,11 +26,15 @@ impl WebSocketHandler for LoggingHandler {
     }
 
     async fn on_disconnected(&mut self, ctx: &WebSocketContext) {
+        let connection_id = match ctx {
+            WebSocketContext::ClientToServer { dst, .. } => dst.to_string(),
+            WebSocketContext::ServerToClient { src, .. } => src.to_string(),
+        };
+
+        // 연결 종료 시 mqtt_versions 항목을 정리해 메모리 누수를 방지한다.
+        self.ws.mqtt_versions.lock().remove(&connection_id);
+
         if let Some(ws_sender) = &self.ws.ws_sender {
-            let connection_id = match ctx {
-                WebSocketContext::ClientToServer { dst, .. } => dst.to_string(),
-                WebSocketContext::ServerToClient { src, .. } => src.to_string(),
-            };
             let event = WsConnectionEvent::Disconnected {
                 connection_id,
                 time: chrono::Local::now()
@@ -46,7 +50,7 @@ impl WebSocketHandler for LoggingHandler {
     async fn handle_message(&mut self, ctx: &WebSocketContext, msg: Message) -> Option<Message> {
         let (direction, connection_id, url) = Self::extract_ws_context(ctx);
 
-        let (message_type, payload, size, is_binary) = match Self::convert_ws_message_payload(&msg)
+        let (message_type, payload, _size, is_binary) = match Self::convert_ws_message_payload(&msg)
         {
             Some(tuple) => tuple,
             None => return Some(msg),
@@ -63,6 +67,9 @@ impl WebSocketHandler for LoggingHandler {
                 is_binary,
             )
             .await?;
+
+        // 스크립트가 메시지를 수정했을 수 있으므로 size를 (수정 후) 실제 메시지에서 다시 계산한다.
+        let size = msg.len();
 
         self.emit_ws_event(
             connection_id,


### PR DESCRIPTION
검증된 `proxy_daemon` Low 버그 6건. (L5 curl 패닉은 #348에서 이미 해소)

| # | 버그 | 위치 |
|---|---|---|
|L6|MapLocal 블로킹 `std::fs::read`를 async 핸들러서 호출|`intercept/actions.rs`|
|L7|스크립트 파일 감시 태스크/소켓 FD 누수(클라이언트 종료 시 미정리)|`client_handler/*`|
|L8|WebSocket mqtt_versions 맵 무한 누수|`ws_handler/handler.rs`,`trait_impl.rs`|
|L9|WS 스크립트 수정 시 잘못된 size 전송|`ws_handler/trait_impl.rs`|
|L10|gRPC compressed flag 무시(압축 프레임 오디코딩)|`proto_registry.rs`|
|L13|WS Modify base64 실패 폴백 시 is_binary 불일치|`ws_handler/handler.rs`|

✅ `cargo build/test -p proxy_daemon` 546 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)