### PR TITLE
cheolsu_ops Low 수정: load_session extend MAX 상한 우회 (L14)

### DIFF
--- a/crates/cheolsu_ops/src/context.rs
+++ b/crates/cheolsu_ops/src/context.rs
@@ -90,6 +90,26 @@ impl OpsStore {
         bounded_push(&self.ws_messages, msg, self.max_ws_messages);
     }
 
+    /// 여러 트랜잭션을 추가하되 상한을 초과하면 가장 오래된 것부터 제거한다(세션/HAR 로드용).
+    pub fn extend_transactions(&self, items: impl IntoIterator<Item = RequestInfo>) {
+        let mut guard = self.transactions.lock();
+        guard.extend(items);
+        if guard.len() > self.max_transactions {
+            let excess = guard.len() - self.max_transactions;
+            guard.drain(0..excess);
+        }
+    }
+
+    /// 여러 WebSocket 메시지를 추가하되 상한을 초과하면 가장 오래된 것부터 제거한다.
+    pub fn extend_ws_messages(&self, items: impl IntoIterator<Item = WsMessageInfo>) {
+        let mut guard = self.ws_messages.lock();
+        guard.extend(items);
+        if guard.len() > self.max_ws_messages {
+            let excess = guard.len() - self.max_ws_messages;
+            guard.drain(0..excess);
+        }
+    }
+
     pub fn push_ws_connection(&self, event: WsConnectionEvent) {
         self.ws_connections.lock().push(event);
     }

--- a/crates/cheolsu_ops/src/session.rs
+++ b/crates/cheolsu_ops/src/session.rs
@@ -92,8 +92,9 @@ pub async fn load_session(ctx: &OpsContext, p: LoadSessionParams) -> OpResult {
         ctx.store.ws_connections.lock().clear();
     }
 
-    ctx.store.transactions.lock().extend(transactions);
-    ctx.store.ws_messages.lock().extend(ws_messages);
+    // extend 시에도 상한을 적용해 메모리 무한 증가를 방지한다(가장 오래된 항목부터 제거).
+    ctx.store.extend_transactions(transactions);
+    ctx.store.extend_ws_messages(ws_messages);
 
     let mut rules_changed = false;
     if !rules.is_empty() {


### PR DESCRIPTION
검증된 `cheolsu_ops` Low 버그 1건.

| # | 버그 | 위치 |
|---|---|---|
|L14|load_session extend가 MAX_TRANSACTIONS/MAX_WS_MESSAGES 상한 우회|`cheolsu_ops/session.rs` + `context.rs`|

OpsStore에 상한 적용 extend 메서드 추가. ✅ `cargo test -p cheolsu_ops` 15 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)