### PR TITLE
src-tauri Low 수정: 로그 경로 탐색/advanced_repeat 지연 (2건)

### DIFF
--- a/desktop/src-tauri/src/proxy_v2/log.rs
+++ b/desktop/src-tauri/src/proxy_v2/log.rs
@@ -60,11 +60,27 @@ pub(crate) async fn get_log_files() -> Result<Vec<LogFileInfo>, String> {
     Ok(files)
 }
 
+/// 로그 파일 경로가 앱 로그 디렉토리 내부인지 검증한다(경로 탐색 방지).
+/// canonicalize로 `..` 우회까지 차단한다.
+fn validate_log_path(path: &str) -> Result<std::path::PathBuf, String> {
+    let app_dir = proxy_daemon::daemon::app_support_dir()
+        .map_err(|e| format!("앱 디렉토리 확인 실패: {}", e))?;
+    let canonical = std::path::Path::new(path)
+        .canonicalize()
+        .map_err(|e| format!("경로 확인 실패: {}", e))?;
+    let app_canonical = app_dir.canonicalize().unwrap_or(app_dir);
+    if !canonical.starts_with(&app_canonical) {
+        return Err("로그 디렉토리 외부 파일은 접근할 수 없습니다".to_string());
+    }
+    Ok(canonical)
+}
+
 #[tauri::command]
 pub(crate) async fn read_log_file(
     path: String,
     tail_lines: Option<usize>,
 ) -> Result<String, String> {
+    let path = validate_log_path(&path)?;
     let content =
         std::fs::read_to_string(&path).map_err(|e| format!("로그 파일 읽기 실패: {}", e))?;
 
@@ -76,18 +92,14 @@ pub(crate) async fn read_log_file(
 
 #[tauri::command]
 pub(crate) async fn clear_log_file(path: String) -> Result<(), String> {
+    let path = validate_log_path(&path)?;
     std::fs::write(&path, "").map_err(|e| format!("로그 파일 초기화 실패: {}", e))
 }
 
 #[tauri::command]
 pub(crate) async fn delete_log_file(path: String) -> Result<(), String> {
-    let path = std::path::Path::new(&path);
-    let app_dir = proxy_daemon::daemon::app_support_dir()
-        .map_err(|e| format!("앱 디렉토리 확인 실패: {}", e))?;
-    if !path.starts_with(&app_dir) {
-        return Err("로그 디렉토리 외부 파일은 삭제할 수 없습니다".to_string());
-    }
-    std::fs::remove_file(path).map_err(|e| format!("로그 파일 삭제 실패: {}", e))
+    let path = validate_log_path(&path)?;
+    std::fs::remove_file(&path).map_err(|e| format!("로그 파일 삭제 실패: {}", e))
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/proxy_v2/replay.rs
+++ b/desktop/src-tauri/src/proxy_v2/replay.rs
@@ -289,11 +289,13 @@ pub(crate) async fn advanced_repeat<R: Runtime>(
                 },
             );
 
-            drop(permit);
-
+            // delay는 permit을 보유한 채 적용해야 동시성/요청 간 간격이 실제로 제어된다.
+            // (permit을 먼저 해제하면 다음 요청이 즉시 시작되어 지연이 무의미해짐)
             if delay_ms > 0 {
                 tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
             }
+
+            drop(permit);
         });
 
         handles.push(handle);


### PR DESCRIPTION
검증된 `src-tauri` Low 버그 2건.

| # | 버그 | 위치 |
|---|---|---|
|L15|read_log_file/clear_log_file 경로 탐색(delete와 비대칭)|`proxy_v2/log.rs`|
|L17|advanced_repeat delay_ms가 permit 해제 후 적용|`proxy_v2/replay.rs`|

✅ `cargo build -p cheolsu-proxy`

⏸ L16(get_learned_tls_strategies)는 UDS request-response 프로토콜 추가가 필요(원저자 TODO)해 Low 대비 과도하여 보류(본문/커밋 참고).

🤖 Generated with [Claude Code](https://claude.com/claude-code)