### PR TITLE
프론트엔드 Low 수정: 분석 count/N+1 오탐/GraphQL 탭 (3건)

### DIFF
--- a/desktop/src/locales/en/messages.po
+++ b/desktop/src/locales/en/messages.po
@@ -342,7 +342,7 @@ msgstr "Backend Scheme"
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:76
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:82
 msgid "Batch"
 msgstr "Batch"
 
@@ -606,7 +606,7 @@ msgstr "Clients without a valid certificate will be rejected"
 #: src/features/transaction-details/ui/advanced-repeat-dialog.tsx:343
 #: src/features/transaction-details/ui/sequence-replay-dialog.tsx:222
 #: src/features/transaction-details/ui/transaction-header.tsx:63
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:159
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:165
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:100
 #: src/widgets/sse-messages/ui/sse-message-detail.tsx:87
 #: src/widgets/websocket-messages/ui/ws-message-detail.tsx:122
@@ -908,7 +908,7 @@ msgid "Duplicate Requests"
 msgstr "Duplicate Requests"
 
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:49
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:62
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:68
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:152
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:33
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:136
@@ -977,7 +977,7 @@ msgstr "Enabled"
 msgid "Encoding"
 msgstr "Encoding"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:59
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:65
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:30
 msgid "Endpoint"
 msgstr "Endpoint"
@@ -1005,7 +1005,7 @@ msgstr "Error Rate"
 msgid "Error Status Code Distribution"
 msgstr "Error Status Code Distribution"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:245
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:251
 msgid "error(s)"
 msgstr "error(s)"
 
@@ -1018,7 +1018,7 @@ msgstr "errors"
 
 #: src/pages/analytics-dashboard/ui/analytics-dashboard.tsx:180
 #: src/pages/analytics-dashboard/ui/error-tab.tsx:72
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:126
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:132
 msgid "Errors"
 msgstr "Errors"
 
@@ -1712,7 +1712,7 @@ msgstr "N+1"
 
 #: src/features/intercept-rule-form/ui/rule-form-dialog.tsx:150
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:190
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:56
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:62
 msgid "Name"
 msgstr "Name"
 
@@ -2190,7 +2190,7 @@ msgstr "proxy.company.com"
 msgid "Python Requests"
 msgstr "Python Requests"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:113
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:119
 msgid "Query"
 msgstr "Query"
 
@@ -2387,7 +2387,7 @@ msgstr "Require certificate"
 #: src/features/transaction-details/ui/replay-dialog.tsx:315
 #: src/features/transaction-details/ui/transaction-body-side-by-side.tsx:24
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:287
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:121
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:127
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:62
 msgid "Response"
 msgstr "Response"
@@ -2834,7 +2834,7 @@ msgstr "Starts background server connection immediately after ClientHello "
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:131
 #: src/pages/log-viewer/ui/logs-page.tsx:465
 #: src/shared/app-sidebar/ui/sidebar-status.tsx:39
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:69
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:75
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:151
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:134
 msgid "Status"
@@ -2959,7 +2959,7 @@ msgstr "Throughput"
 #: src/pages/analytics-dashboard/ui/misc-tab.tsx:40
 #: src/pages/analytics-dashboard/ui/misc-tab.tsx:90
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:55
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:60
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:66
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:153
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:31
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:137
@@ -3056,7 +3056,7 @@ msgid "Trusted"
 msgstr "Trusted"
 
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:241
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:52
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:58
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:149
 #: src/widgets/websocket-messages/ui/ws-message-detail.tsx:50
 #: src/widgets/websocket-messages/ui/ws-message-table.tsx:184
@@ -3183,7 +3183,7 @@ msgstr "Validity Period"
 msgid "Value"
 msgstr "Value"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:116
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:122
 msgid "Variables"
 msgstr "Variables"
 

--- a/desktop/src/locales/ko/messages.po
+++ b/desktop/src/locales/ko/messages.po
@@ -337,7 +337,7 @@ msgstr "백엔드 스킴"
 msgid "Base URL"
 msgstr "기본 URL"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:76
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:82
 msgid "Batch"
 msgstr "배치"
 
@@ -601,7 +601,7 @@ msgstr "유효한 인증서가 없는 클라이언트는 거부됩니다"
 #: src/features/transaction-details/ui/advanced-repeat-dialog.tsx:343
 #: src/features/transaction-details/ui/sequence-replay-dialog.tsx:222
 #: src/features/transaction-details/ui/transaction-header.tsx:63
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:159
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:165
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:100
 #: src/widgets/sse-messages/ui/sse-message-detail.tsx:87
 #: src/widgets/websocket-messages/ui/ws-message-detail.tsx:122
@@ -894,7 +894,7 @@ msgid "Duplicate Requests"
 msgstr "중복 요청"
 
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:49
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:62
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:68
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:152
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:33
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:136
@@ -962,7 +962,7 @@ msgstr "활성"
 msgid "Encoding"
 msgstr ""
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:59
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:65
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:30
 msgid "Endpoint"
 msgstr "엔드포인트"
@@ -990,7 +990,7 @@ msgstr "에러율"
 msgid "Error Status Code Distribution"
 msgstr "에러 상태 코드 분포"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:245
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:251
 msgid "error(s)"
 msgstr "에러"
 
@@ -1003,7 +1003,7 @@ msgstr "오류"
 
 #: src/pages/analytics-dashboard/ui/analytics-dashboard.tsx:180
 #: src/pages/analytics-dashboard/ui/error-tab.tsx:72
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:126
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:132
 msgid "Errors"
 msgstr "에러"
 
@@ -1691,7 +1691,7 @@ msgstr "N+1"
 
 #: src/features/intercept-rule-form/ui/rule-form-dialog.tsx:150
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:190
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:56
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:62
 msgid "Name"
 msgstr "이름"
 
@@ -2160,7 +2160,7 @@ msgstr "proxy.company.com"
 msgid "Python Requests"
 msgstr "Python Requests"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:113
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:119
 msgid "Query"
 msgstr "쿼리"
 
@@ -2353,7 +2353,7 @@ msgstr "인증서 필수"
 #: src/features/transaction-details/ui/replay-dialog.tsx:315
 #: src/features/transaction-details/ui/transaction-body-side-by-side.tsx:24
 #: src/pages/breakpoint/ui/breakpoint-page.tsx:287
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:121
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:127
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:62
 msgid "Response"
 msgstr "응답"
@@ -2797,7 +2797,7 @@ msgstr "ClientHello 감지 직후 백그라운드에서 서버 연결을 시작�
 #: src/pages/intercept-rules/ui/intercept-rules-page.tsx:131
 #: src/pages/log-viewer/ui/logs-page.tsx:465
 #: src/shared/app-sidebar/ui/sidebar-status.tsx:39
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:69
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:75
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:151
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:134
 msgid "Status"
@@ -2918,7 +2918,7 @@ msgstr "처리량"
 #: src/pages/analytics-dashboard/ui/misc-tab.tsx:40
 #: src/pages/analytics-dashboard/ui/misc-tab.tsx:90
 #: src/pages/analytics-dashboard/ui/performance-tab.tsx:55
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:60
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:66
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:153
 #: src/widgets/grpc-calls/ui/grpc-call-detail.tsx:31
 #: src/widgets/grpc-calls/ui/grpc-call-table.tsx:137
@@ -3015,7 +3015,7 @@ msgid "Trusted"
 msgstr "신뢰됨"
 
 #: src/features/map-rule-form/ui/map-rule-form-dialog.tsx:241
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:52
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:58
 #: src/widgets/graphql-operations/ui/graphql-operation-table.tsx:149
 #: src/widgets/websocket-messages/ui/ws-message-detail.tsx:50
 #: src/widgets/websocket-messages/ui/ws-message-table.tsx:184
@@ -3139,7 +3139,7 @@ msgstr "유효 기간"
 msgid "Value"
 msgstr "값"
 
-#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:116
+#: src/widgets/graphql-operations/ui/graphql-operation-detail.tsx:122
 msgid "Variables"
 msgstr "변수"
 

--- a/desktop/src/pages/analytics-dashboard/lib/analytics-engine.ts
+++ b/desktop/src/pages/analytics-dashboard/lib/analytics-engine.ts
@@ -231,6 +231,7 @@ export function analyzeEndpoints(
     {
       method: string;
       path: string;
+      count: number;
       durations: number[];
       errorCount: number;
       responseSizes: number[];
@@ -245,12 +246,14 @@ export function analyzeEndpoints(
       map.set(key, {
         method: tx.request.method,
         path: getPath(tx.request.uri),
+        count: 0,
         durations: [],
         errorCount: 0,
         responseSizes: [],
       });
     }
     const ep = map.get(key)!;
+    ep.count += 1;
 
     const d = getDuration(tx);
     if (d != null && d >= 0) ep.durations.push(d);
@@ -262,7 +265,8 @@ export function analyzeEndpoints(
 
   const stats: EndpointStat[] = Array.from(map.values()).map((ep) => {
     const sorted = [...ep.durations].sort((a, b) => a - b);
-    const totalCount = Math.max(ep.durations.length, ep.responseSizes.length, 1);
+    // count는 실제 요청 수를 사용한다(과거엔 duration/응답 개수의 max라 부정확했음).
+    const totalCount = ep.count;
     return {
       method: ep.method,
       path: ep.path,
@@ -352,12 +356,19 @@ export function detectNPlusOne(transactions: HttpTransaction[], threshold = 3): 
 
   // Detect repetitive patterns: same base path with different IDs
   const pathPattern = /^(.*\/)[^/]+$/;
+  // 마지막 세그먼트가 ID(숫자 또는 UUID)인 요청만 N+1 후보로 본다.
+  // (그렇지 않으면 /api/users, /api/posts 같은 형제 엔드포인트가 /api/로 묶여 오탐)
+  const idSegment =
+    /^(\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
 
   for (const tx of sorted) {
     if (!tx.request) continue;
     const path = getPath(tx.request.uri);
     const match = pathPattern.exec(path);
     if (!match) continue;
+
+    const lastSegment = path.slice(match[1].length);
+    if (!idSegment.test(lastSegment)) continue;
 
     const basePath = match[1];
     const key = `${tx.request.method} ${basePath}`;

--- a/desktop/src/widgets/graphql-operations/ui/graphql-operation-detail.tsx
+++ b/desktop/src/widgets/graphql-operations/ui/graphql-operation-detail.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useLingui } from "@lingui/react/macro";
 import { Trans } from "@lingui/react/macro";
 import { X, AlertTriangle } from "lucide-react";
@@ -45,6 +45,12 @@ export const GraphqlOperationDetail = memo(
     const hasErrors = operation.responseErrors && operation.responseErrors.length > 0;
 
     const [activeTab, setActiveTab] = useState<DetailTab>("query");
+
+    // 다른 오퍼레이션으로 전환되면 탭을 기본값으로 초기화한다.
+    // (이전에 선택한 탭이 새 오퍼레이션에 없으면 빈 화면이 표시되던 문제 방지)
+    useEffect(() => {
+      setActiveTab("query");
+    }, [operation.id]);
 
     const metaItems = useMemo(() => {
       const items = [


### PR DESCRIPTION
검증된 프론트엔드 Low 버그 3건(FE-L2 analyzeEndpoints count, FE-L3 detectNPlusOne 형제 오탐, FE-L4 GraphQL activeTab 미초기화). FE-L1(multipart 바이너리 size)은 바이트 단위 파서 재작성이 필요해 보류. ✅ lint/build/test 584 pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)