### PR TITLE
scripting: load_script 홈 디렉터리 경계 추가 (경로 탐색 방어심층, L12)

### DIFF
--- a/crates/scripting/src/engine/loader.rs
+++ b/crates/scripting/src/engine/loader.rs
@@ -4,6 +4,13 @@ use tracing::info;
 
 use super::ScriptEngine;
 
+/// 사용자 홈 디렉터리(HOME 또는 USERPROFILE)를 반환한다. 알 수 없으면 None.
+fn home_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+}
+
 impl ScriptEngine {
     /// 사용자 스크립트 파일 로드 (JS/TS 모두 지원)
     pub fn load_script(&mut self, path: &str) -> Result<(), ScriptError> {
@@ -23,6 +30,19 @@ impl ScriptEngine {
             _ => {
                 return Err(ScriptError::InvalidExtension {
                     path: path.to_string(),
+                });
+            }
+        }
+
+        // 디렉터리 화이트리스트: 스크립트는 사용자 홈 디렉터리 내부 파일만 허용한다.
+        // (확장자 검증 + v8 샌드박스(fs/net op 미노출)로 영향은 작지만, untrusted 호출자가
+        //  시스템 경로의 .js를 읽어 실행하는 것을 차단하는 방어심층 계층)
+        // 홈 디렉터리를 알 수 없는 환경에서는 제한하지 않는다(정상 동작 보장).
+        if let Some(home) = home_dir().and_then(|h| h.canonicalize().ok()) {
+            if !canonical.starts_with(&home) {
+                return Err(ScriptError::PathResolution {
+                    path: path.to_string(),
+                    reason: "스크립트는 홈 디렉터리 내부 파일만 로드할 수 있습니다".to_string(),
                 });
             }
         }


### PR DESCRIPTION
보류했던 L12를 루트코즈까지 처리.

**루트코즈**: load_script가 디렉터리 화이트리스트 없이 임의 경로의 .js를 로드 가능.
**분석**: v8 샌드박스에 fs/net op이 노출되지 않아 실제 악용 영향은 낮으나, untrusted 호출자(MCP)의 시스템 경로 읽기를 차단하는 방어심층이 필요.
**수정**: 스크립트를 사용자 홈 디렉터리 내부로 제한(홈 미확인 시 비제한 — 정상 동작 보장).

✅ `cargo build/test -p scripting` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)