### PR TITLE
WebSocket: 연결별 고유 conn_id로 동시 연결 충돌 해결 (L2)

### DIFF
--- a/crates/proxy_daemon/src/ws_handler/handler.rs
+++ b/crates/proxy_daemon/src/ws_handler/handler.rs
@@ -8,15 +8,18 @@ use crate::handler::LoggingHandler;
 impl LoggingHandler {
     /// WebSocketContext에서 방향, connection_id, URL을 추출합니다.
     pub(crate) fn extract_ws_context(ctx: &WebSocketContext) -> (WsDirection, String, String) {
+        // connection_id는 고유 conn_id를 사용하고, URL은 표시용으로 src/dst에서 얻는다.
         match ctx {
-            WebSocketContext::ClientToServer { dst, .. } => {
-                let url = dst.to_string();
-                (WsDirection::ClientToServer, url.clone(), url)
-            }
-            WebSocketContext::ServerToClient { src, .. } => {
-                let url = src.to_string();
-                (WsDirection::ServerToClient, url.clone(), url)
-            }
+            WebSocketContext::ClientToServer { dst, conn_id, .. } => (
+                WsDirection::ClientToServer,
+                conn_id.clone(),
+                dst.to_string(),
+            ),
+            WebSocketContext::ServerToClient { src, conn_id, .. } => (
+                WsDirection::ServerToClient,
+                conn_id.clone(),
+                src.to_string(),
+            ),
         }
     }
 

--- a/crates/proxy_daemon/src/ws_handler/trait_impl.rs
+++ b/crates/proxy_daemon/src/ws_handler/trait_impl.rs
@@ -8,9 +8,14 @@ use crate::handler::LoggingHandler;
 impl WebSocketHandler for LoggingHandler {
     async fn on_connected(&mut self, ctx: &WebSocketContext) {
         if let Some(ws_sender) = &self.ws.ws_sender {
+            // connection_id는 고유 conn_id를 사용하고, uri는 표시용으로 src/dst에서 얻는다.
             let (connection_id, uri) = match ctx {
-                WebSocketContext::ClientToServer { dst, .. } => (dst.to_string(), dst.to_string()),
-                WebSocketContext::ServerToClient { src, .. } => (src.to_string(), src.to_string()),
+                WebSocketContext::ClientToServer { dst, conn_id, .. } => {
+                    (conn_id.clone(), dst.to_string())
+                }
+                WebSocketContext::ServerToClient { src, conn_id, .. } => {
+                    (conn_id.clone(), src.to_string())
+                }
             };
             let event = WsConnectionEvent::Connected {
                 connection_id,
@@ -27,8 +32,8 @@ impl WebSocketHandler for LoggingHandler {
 
     async fn on_disconnected(&mut self, ctx: &WebSocketContext) {
         let connection_id = match ctx {
-            WebSocketContext::ClientToServer { dst, .. } => dst.to_string(),
-            WebSocketContext::ServerToClient { src, .. } => src.to_string(),
+            WebSocketContext::ClientToServer { conn_id, .. } => conn_id.clone(),
+            WebSocketContext::ServerToClient { conn_id, .. } => conn_id.clone(),
         };
 
         // 연결 종료 시 mqtt_versions 항목을 정리해 메모리 누수를 방지한다.

--- a/crates/proxyapi_v2/src/lib.rs
+++ b/crates/proxyapi_v2/src/lib.rs
@@ -107,6 +107,8 @@ pub enum WebSocketContext {
         src: SocketAddr,
         /// URI of the server.
         dst: Uri,
+        /// 연결별 고유 식별자(URI가 아닌 고유 ID — 동일 URI 동시 연결을 구분).
+        conn_id: String,
     },
     #[non_exhaustive]
     ServerToClient {
@@ -114,6 +116,8 @@ pub enum WebSocketContext {
         src: Uri,
         /// Address of the client.
         dst: SocketAddr,
+        /// 연결별 고유 식별자.
+        conn_id: String,
     },
 }
 

--- a/crates/proxyapi_v2/src/proxy/websocket.rs
+++ b/crates/proxyapi_v2/src/proxy/websocket.rs
@@ -219,8 +219,10 @@ where
         let (inject_to_server_tx, inject_to_server_rx) =
             mpsc::channel::<Message>(WS_INJECT_CHANNEL_CAPACITY);
 
-        // 레지스트리에 등록
-        let conn_id = uri.to_string();
+        // 레지스트리에 등록.
+        // conn_id는 URI가 아닌 연결별 고유 ID를 사용한다(동일 URI로의 동시 연결이
+        // 레지스트리 키를 덮어쓰거나 교차 unregister되는 문제 방지).
+        let conn_id = uuid::Uuid::new_v4().to_string();
         if let Some(ref registry) = self.ctx.websocket_registry {
             let injector =
                 WebSocketInjector::new(inject_to_client_tx.clone(), inject_to_server_tx.clone());
@@ -235,6 +237,7 @@ where
         let connected_ctx = WebSocketContext::ServerToClient {
             src: uri.clone(),
             dst: client_addr,
+            conn_id: conn_id.clone(),
         };
         websocket_handler.on_connected(&connected_ctx).await;
 
@@ -250,6 +253,7 @@ where
             WebSocketContext::ServerToClient {
                 src: uri.clone(),
                 dst: client_addr,
+                conn_id: conn_id.clone(),
             },
             registry_clone,
             conn_id_clone,
@@ -265,6 +269,7 @@ where
             WebSocketContext::ClientToServer {
                 src: client_addr,
                 dst: uri,
+                conn_id: conn_id.clone(),
             },
             websocket_registry,
             conn_id,


### PR DESCRIPTION
보류했던 L2를 루트코즈까지 수정.

**루트코즈**: conn_id가 `uri.to_string()` → 동일 URI 동시 연결이 레지스트리 키를 덮어쓰고 교차 unregister → 메시지 주입 오라우팅/유실.

**수정**: `WebSocketContext`에 연결별 고유 conn_id(UUID)를 추가해 proxyapi_v2 레지스트리 키와 daemon 이벤트가 동일 ID를 쓰도록 3계층 전파. URI는 표시용 별도 필드로 유지(GUI 호환).

✅ proxy_daemon 546 + proxyapi_v2(full) 258 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)