### PR TITLE
TLS: get_learned_tls_strategies request-response 구현 (L16)

### DIFF
--- a/crates/proxy_daemon/src/client.rs
+++ b/crates/proxy_daemon/src/client.rs
@@ -405,3 +405,52 @@ async fn run_event_loop<F>(
         }
     }
 }
+
+/// 데몬에 일회성으로 연결하여 학습된 TLS 전략을 동기 조회한다(request-response).
+///
+/// 데몬은 GetLearnedTlsStrategies에 대한 응답(LearnedTlsStrategies)을 "요청한 연결의
+/// writer"로 돌려보내므로, 전용 단명 연결로 명령을 보내고 해당 응답을 읽으면 된다.
+/// (기존 메인 연결은 콜백 기반 스트림이라 특정 응답을 await할 수 없다)
+pub async fn query_learned_tls_strategies(
+) -> Result<Vec<proxyapi_v2::hybrid_tls_handler::LearnedTlsStrategy>, DaemonError> {
+    let uds_path = uds_socket_path()?;
+    let stream = UnixStream::connect(&uds_path)
+        .await
+        .map_err(|e| DaemonError::Uds(format!("connect: {}", e)))?;
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(reader);
+
+    let mut line = serde_json::to_string(&ClientCommand::GetLearnedTlsStrategies)?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| DaemonError::Uds(format!("write: {}", e)))?;
+    writer
+        .flush()
+        .await
+        .map_err(|e| DaemonError::Uds(format!("flush: {}", e)))?;
+
+    // 응답(LearnedTlsStrategies)을 만날 때까지 라인을 읽는다(연결 직후의 Status 등은 건너뜀).
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            reader.read_line(&mut buf),
+        )
+        .await
+        .map_err(|_| DaemonError::Uds("학습된 TLS 전략 응답 타임아웃".to_string()))?
+        .map_err(|e| DaemonError::Uds(format!("read: {}", e)))?;
+        if read == 0 {
+            break; // EOF
+        }
+        if let Ok(DaemonMessage::LearnedTlsStrategies { strategies }) =
+            serde_json::from_str::<DaemonMessage>(buf.trim())
+        {
+            return Ok(strategies);
+        }
+    }
+
+    Ok(Vec::new())
+}

--- a/crates/proxy_daemon/src/lib.rs
+++ b/crates/proxy_daemon/src/lib.rs
@@ -30,7 +30,8 @@ pub(crate) mod ws_handler;
 // Re-exports for convenience
 pub use breakpoint::BreakpointManager;
 pub use client::{
-    connect_to_daemon, ensure_daemon, is_daemon_running, CommandSender, DaemonConnection,
+    connect_to_daemon, ensure_daemon, is_daemon_running, query_learned_tls_strategies,
+    CommandSender, DaemonConnection,
 };
 pub use contract_validator::ContractValidator;
 pub use daemon::{check_and_cleanup_stale_lock, lock_file_path, run_daemon, uds_socket_path};

--- a/desktop/src-tauri/src/proxy_v2/tls_passthrough.rs
+++ b/desktop/src-tauri/src/proxy_v2/tls_passthrough.rs
@@ -139,16 +139,12 @@ pub(crate) async fn get_tls_config_rules(
 }
 
 #[tauri::command]
-pub(crate) async fn get_learned_tls_strategies(
-    proxy: State<'_, ProxyV2State>,
-) -> Result<Vec<LearnedTlsStrategy>, String> {
-    let sender = get_command_sender(&proxy).await?;
-    sender
-        .send_command(&ClientCommand::GetLearnedTlsStrategies)
+pub(crate) async fn get_learned_tls_strategies() -> Result<Vec<LearnedTlsStrategy>, String> {
+    // 데몬에 일회성 연결로 학습된 TLS 전략을 동기 조회한다(request-response).
+    // 데몬 미실행 시 연결 에러를 반환하며, 프론트는 이를 빈 배열로 graceful 처리한다.
+    proxy_daemon::query_learned_tls_strategies()
         .await
-        .map_err(|e| format!("학습된 TLS 전략 조회 실패: {}", e))?;
-    // TODO: 데몬 응답을 비동기로 수신하여 반환
-    Ok(vec![])
+        .map_err(|e| format!("학습된 TLS 전략 조회 실패: {}", e))
 }
 
 #[tauri::command]


### PR DESCRIPTION
보류했던 L16을 루트코즈까지 처리.

**루트코즈**: get_learned_tls_strategies가 fire-and-forget 후 응답을 받지 않고 항상 `vec![]` 반환(TODO). 메인 연결이 콜백 기반 스트림이라 특정 응답을 await 불가.

**수정**: 데몬이 응답을 요청 연결로 돌려보내는 점을 이용해 일회성 연결로 동기 request-response하는 `query_learned_tls_strategies()`를 추가하고 tauri command가 사용. 데몬 미실행 시 graceful(빈 배열).

✅ `cargo build -p proxy_daemon -p cheolsu-proxy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)