### PR TITLE
fix: 코드리뷰 발견 스크립트/규칙 하드닝 (오버플로·watcher·terminate race·로더 회귀)

### DIFF
--- a/crates/cheolsu_ops/src/id.rs
+++ b/crates/cheolsu_ops/src/id.rs
@@ -13,8 +13,11 @@ fn observe_counter(counter: &AtomicU32, id: &str, prefix: &str) {
         return;
     };
     let mut cur = counter.load(Ordering::Relaxed);
+    // n == u32::MAX인 ID("rule_4294967295")를 로드하면 n + 1이 오버플로(디버그 패닉/
+    // 릴리스 wrap)된다. saturating_add로 패닉 없이 카운터를 끌어올린다.
+    let target = n.saturating_add(1);
     while n >= cur {
-        match counter.compare_exchange_weak(cur, n + 1, Ordering::Relaxed, Ordering::Relaxed) {
+        match counter.compare_exchange_weak(cur, target, Ordering::Relaxed, Ordering::Relaxed) {
             Ok(_) => break,
             Err(actual) => cur = actual,
         }
@@ -50,4 +53,32 @@ pub fn next_server_replay_id() -> String {
         "sr_{}",
         SERVER_REPLAY_COUNTER.fetch_add(1, Ordering::Relaxed)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_at_u32_max_does_not_overflow() {
+        let counter = AtomicU32::new(0);
+        // n == u32::MAX인 ID를 관찰해도 패닉 없이 종료해야 한다.
+        observe_counter(&counter, "rule_4294967295", "rule_");
+        assert_eq!(counter.load(Ordering::Relaxed), u32::MAX);
+    }
+
+    #[test]
+    fn observe_raises_counter_above_loaded_id() {
+        let counter = AtomicU32::new(0);
+        observe_counter(&counter, "rule_41", "rule_");
+        assert_eq!(counter.load(Ordering::Relaxed), 42);
+    }
+
+    #[test]
+    fn observe_ignores_mismatched_prefix_or_garbage() {
+        let counter = AtomicU32::new(7);
+        observe_counter(&counter, "bp_100", "rule_");
+        observe_counter(&counter, "rule_abc", "rule_");
+        assert_eq!(counter.load(Ordering::Relaxed), 7);
+    }
 }

--- a/crates/proxy_daemon/src/client_handler/commands.rs
+++ b/crates/proxy_daemon/src/client_handler/commands.rs
@@ -236,6 +236,17 @@ pub(super) async fn handle_command(cmd: ClientCommand, ctx: &CommandState) -> bo
                         if let Some(old) = ctx.watcher_handle.lock().await.replace(new_handle) {
                             old.abort();
                         }
+                    } else {
+                        // 코드 스크립트(path=None)는 감시 대상이 없다. 이전 파일 watcher가
+                        // 남아 있으면 옛 파일 변경 이벤트가 방금 로드한 코드 스크립트를
+                        // 덮어쓰므로, watched_path를 비우고 이전 watcher를 중단한다.
+                        {
+                            let mut wp = ctx.watched_path.lock().await;
+                            *wp = None;
+                        }
+                        if let Some(old) = ctx.watcher_handle.lock().await.take() {
+                            old.abort();
+                        }
                     }
                     // 스크립트 상태 브로드캐스트
                     s.broadcast_event(&DaemonMessage::ScriptStatus {

--- a/crates/scripting/src/engine/loader.rs
+++ b/crates/scripting/src/engine/loader.rs
@@ -4,13 +4,6 @@ use tracing::info;
 
 use super::ScriptEngine;
 
-/// 사용자 홈 디렉터리(HOME 또는 USERPROFILE)를 반환한다. 알 수 없으면 None.
-fn home_dir() -> Option<std::path::PathBuf> {
-    std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(std::path::PathBuf::from)
-}
-
 impl ScriptEngine {
     /// 사용자 스크립트 파일 로드 (JS/TS 모두 지원)
     pub fn load_script(&mut self, path: &str) -> Result<(), ScriptError> {
@@ -34,19 +27,10 @@ impl ScriptEngine {
             }
         }
 
-        // 디렉터리 화이트리스트: 스크립트는 사용자 홈 디렉터리 내부 파일만 허용한다.
-        // (확장자 검증 + v8 샌드박스(fs/net op 미노출)로 영향은 작지만, untrusted 호출자가
-        //  시스템 경로의 .js를 읽어 실행하는 것을 차단하는 방어심층 계층)
-        // 홈 디렉터리를 알 수 없는 환경에서는 제한하지 않는다(정상 동작 보장).
-        if let Some(home) = home_dir().and_then(|h| h.canonicalize().ok()) {
-            if !canonical.starts_with(&home) {
-                return Err(ScriptError::PathResolution {
-                    path: path.to_string(),
-                    reason: "스크립트는 홈 디렉터리 내부 파일만 로드할 수 있습니다".to_string(),
-                });
-            }
-        }
-
+        // 디렉터리 화이트리스트는 두지 않는다. 스크립트는 운영자가 직접 지정한 자기 자신의
+        // 파일이며, deno_core 샌드박스(fs/net op 미노출)가 실제 격리 계층이다. 홈 디렉터리
+        // 제한은 보안 이득이 미미한 반면 /tmp·외부 볼륨·홈 밖 프로젝트의 정상 스크립트 로드를
+        // 막는 회귀를 유발하므로, path traversal 방지(canonicalize)와 확장자 검증만 유지한다.
         let source = std::fs::read_to_string(&canonical)?;
 
         let code = if path.ends_with(".ts") || path.ends_with(".tsx") {

--- a/crates/scripting/src/handle.rs
+++ b/crates/scripting/src/handle.rs
@@ -449,6 +449,11 @@ where
     let mut e = ScriptEngine::new()?;
     // 로드(최상위 코드)에서 무한 루프가 발생해도 외부에서 terminate할 수 있도록 핸들을 먼저 등록
     set_isolate(control, Some(e.isolate_handle()));
+    // 이전 훅의 늦은 타임아웃이 남긴 stale terminated 플래그가 새 로드를 즉시 시간 초과로
+    // 오판하지 않도록 초기화한다(새 isolate라 V8 latch는 이미 없다).
+    control
+        .terminated
+        .store(false, std::sync::atomic::Ordering::Release);
     let r = load(&mut e);
     flush_logs(&mut e, log_tx);
     if control
@@ -467,6 +472,23 @@ where
             set_isolate(control, None);
             Err(err)
         }
+    }
+}
+
+/// 훅 실행 직전, 이전 훅의 늦은 타임아웃이 남긴 stale terminate 상태를 제거한다.
+///
+/// 어떤 훅이 타임아웃 직전에 정상 완료되면, 호출자 측 `terminate_running_script`가
+/// 이미 idle 상태인 isolate에 `terminate_execution`을 latch하고 `terminated` 플래그를
+/// 남길 수 있다. 이 상태가 남아 있으면 *다음* 정상 훅이 곧바로 강제 종료된다.
+/// 따라서 각 훅 실행 전에 플래그와 V8 latch를 모두 비워 클린 상태로 시작한다
+/// (이 시점에는 아직 훅이 실행되지 않았으므로 정상 terminate가 진행 중일 수 없다).
+fn clear_stale_termination(engine: &mut Option<ScriptEngine>, control: &Arc<EngineControl>) {
+    control
+        .terminated
+        .store(false, std::sync::atomic::Ordering::Release);
+    if let Some(e) = engine.as_mut() {
+        // latch가 없으면 무해한 no-op이므로 무조건 호출해 플래그/latch desync도 정리한다.
+        e.cancel_termination();
     }
 }
 
@@ -525,6 +547,7 @@ async fn script_engine_loop(
                 break;
             }
             ScriptCommand::InvokeOnRequest { request, reply } => {
+                clear_stale_termination(&mut engine, &control);
                 let result = if let Some(e) = engine.as_mut() {
                     let r = e.invoke_on_request(&request).await;
                     flush_logs(e, &log_tx);
@@ -540,6 +563,7 @@ async fn script_engine_loop(
                 response,
                 reply,
             } => {
+                clear_stale_termination(&mut engine, &control);
                 let result = if let Some(e) = engine.as_mut() {
                     let r = e.invoke_on_response(&request, &response).await;
                     flush_logs(e, &log_tx);
@@ -551,6 +575,7 @@ async fn script_engine_loop(
                 let _ = reply.send(result);
             }
             ScriptCommand::InvokeOnWsMessage { message, reply } => {
+                clear_stale_termination(&mut engine, &control);
                 let result = if let Some(e) = engine.as_mut() {
                     let r = e.invoke_on_ws_message(&message).await;
                     flush_logs(e, &log_tx);
@@ -562,6 +587,7 @@ async fn script_engine_loop(
                 let _ = reply.send(result);
             }
             ScriptCommand::InvokeOnSseEvent { event, reply } => {
+                clear_stale_termination(&mut engine, &control);
                 let result = if let Some(e) = engine.as_mut() {
                     let r = e.invoke_on_sse_event(&event).await;
                     flush_logs(e, &log_tx);
@@ -642,5 +668,34 @@ mod tests {
             .expect("shutdown이 무한 블로킹 없이 완료되어야 함");
 
         invoke.abort();
+    }
+
+    /// 회귀: idle 상태에서 늦게 도착한 terminate(이전 훅의 타임아웃 잔재)가
+    /// 다음 정상 훅을 잘못 강제 종료해서는 안 된다.
+    #[tokio::test]
+    async fn stale_terminate_does_not_poison_next_hook() {
+        let handle = ScriptHandle::new_with_timeout(Duration::from_secs(5));
+        handle
+            .load_code("cheolsu.onRequest((req) => ({ action: 'forward' }));")
+            .await
+            .expect("정상 훅 로드 성공");
+
+        // 첫 정상 호출은 성공한다.
+        let r1 = handle.invoke_on_request(&dummy_request()).await;
+        assert!(r1.is_ok(), "첫 호출은 성공해야 함: {:?}", r1);
+
+        // 엔진이 idle인 상태에서 stale terminate를 시뮬레이션한다
+        // (이전 훅이 타임아웃 직전 완료되어 idle isolate에 terminate가 latch된 상황).
+        handle.terminate_running_script();
+
+        // 다음 정상 호출이 stale terminate로 잘못 강제 종료되지 않아야 한다.
+        let r2 = handle.invoke_on_request(&dummy_request()).await;
+        assert!(
+            r2.is_ok(),
+            "stale terminate가 다음 정상 훅을 종료시키면 안 됨: {:?}",
+            r2
+        );
+
+        handle.shutdown().await;
     }
 }


### PR DESCRIPTION
`/code-review max` 코드리뷰에서 발견된, 이전 수정에서 유입된 회귀/갭 4건을 정리합니다.

## 1. `id.rs` — observe_counter 오버플로 (M)
세션/HAR 로드 시 id가 `rule_4294967295`(u32::MAX)이면 `n + 1`이 오버플로(디버그 패닉/릴리스 wrap). `saturating_add`로 수정. 테스트 3종 추가.

## 2. `commands.rs` (LoadScript) — 코드 스크립트 로드 시 watcher 누수/덮어쓰기 (M)
파일 스크립트 로드 후 **코드 스크립트(path=None)** 를 로드하면 이전 파일 watcher가 abort되지 않아, 옛 파일이 변경되면 방금 로드한 코드 스크립트를 덮어씀. `else` 분기에서 `watched_path`를 비우고 이전 watcher를 중단하도록 수정.

## 3. `handle.rs` — terminate race (M)
훅이 타임아웃 직전 정상 완료되면 호출자 측 `terminate_running_script`가 idle isolate에 `terminate_execution`을 latch → **다음 정상 훅이 즉시 강제 종료**. 각 훅 실행 직전 `clear_stale_termination`으로 플래그+V8 latch를 비우고, `build_engine` 진입 시 플래그를 초기화. 회귀 테스트 추가.

## 4. `loader.rs` — 홈 디렉터리 화이트리스트 회귀 (M, 되돌림)
이전 L12 수정이 추가한 홈 디렉터리 제한은 deno_core 샌드박스(fs/net op 미노출)로 보안 이득이 미미한 반면 `/tmp`·외부 볼륨·홈 밖 프로젝트의 **정상 스크립트 로드를 차단**하는 회귀. path traversal 방지(`canonicalize`)와 확장자 검증은 유지하고 디렉터리 제한만 제거.

## 테스트
`cheolsu_ops` 18, `scripting` 22, `proxy_daemon` 546 등 전 스위트 통과(신규 회귀 테스트 4건 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)