### PR TITLE
fix: 스크립트 바디 교체 시 stale content-length/encoding 헤더 제거

### DIFF
--- a/crates/proxy_daemon/src/script_bridge/mod.rs
+++ b/crates/proxy_daemon/src/script_bridge/mod.rs
@@ -61,6 +61,10 @@ impl LoggingHandler {
         // Body 수정
         if let Some(body) = &modified.body {
             req = req.map(|_| Body::from(body.clone()));
+            // 바디를 교체하면 원본 content-length/encoding이 무효화된다. 스크립트가 받은
+            // 헤더 맵에 원본 값이 그대로 남아 있을 수 있으므로 제거한다(intercept/breakpoint
+            // 경로와 동일하게: 길이 mismatch 및 잘못된 디코딩으로 인한 손상 방지).
+            crate::header_utils::clear_content_encoding_headers(req.headers_mut());
         }
         req
     }
@@ -107,6 +111,10 @@ impl LoggingHandler {
         }
 
         if let Some(new_body) = &modified.body {
+            // 바디를 교체하면 원본 content-length/content-encoding(예: gzip)이 무효화된다.
+            // 제거하지 않으면 클라이언트가 평문을 gzip으로 디코딩하려다 손상되거나 길이가
+            // 어긋난다(intercept/breakpoint 경로와 동일).
+            crate::header_utils::clear_content_encoding_headers(&mut parts.headers);
             Response::from_parts(parts, Body::from(new_body.clone()))
         } else {
             Response::from_parts(parts, body)

--- a/crates/proxy_daemon/src/script_bridge/tests.rs
+++ b/crates/proxy_daemon/src/script_bridge/tests.rs
@@ -408,3 +408,93 @@ fn test_apply_script_response_modify_invalid_status_ignored() {
 
     assert_eq!(result.status(), StatusCode::OK);
 }
+
+// ── 바디 교체 시 stale content-length/encoding 헤더 제거 (회귀) ──
+
+#[test]
+fn test_apply_script_request_modify_body_clears_encoding_headers() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("http://example.com")
+        .body(Body::from("old body"))
+        .unwrap();
+
+    // 스크립트가 받은 헤더 맵에는 원본 content-length/encoding이 그대로 들어 있다.
+    let mut headers = HashMap::new();
+    headers.insert("content-length".to_string(), "8".to_string());
+    headers.insert("content-encoding".to_string(), "gzip".to_string());
+    headers.insert("transfer-encoding".to_string(), "chunked".to_string());
+    headers.insert("x-keep".to_string(), "yes".to_string());
+
+    let modified = make_script_request(
+        "POST",
+        "http://example.com",
+        headers,
+        Some("a much longer new body".to_string()),
+    );
+    let result = LoggingHandler::apply_script_request_modify(req, &modified);
+
+    // 바디를 교체했으므로 길이/인코딩 헤더는 제거되어야 한다.
+    assert!(result.headers().get("content-length").is_none());
+    assert!(result.headers().get("content-encoding").is_none());
+    assert!(result.headers().get("transfer-encoding").is_none());
+    // 그 외 헤더는 유지.
+    assert_eq!(result.headers().get("x-keep").unwrap(), "yes");
+}
+
+#[test]
+fn test_apply_script_request_modify_no_body_keeps_headers() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("http://example.com")
+        .body(Body::from("body"))
+        .unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert("content-length".to_string(), "4".to_string());
+    let modified = make_script_request("POST", "http://example.com", headers, None);
+    let result = LoggingHandler::apply_script_request_modify(req, &modified);
+
+    // 바디를 교체하지 않으면 헤더는 스크립트가 준 그대로 유지된다.
+    assert_eq!(result.headers().get("content-length").unwrap(), "4");
+}
+
+#[test]
+fn test_apply_script_response_modify_body_clears_encoding_headers() {
+    let res = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-length", "8")
+        .header("content-encoding", "gzip")
+        .header("transfer-encoding", "chunked")
+        .header("x-keep", "yes")
+        .body(Body::from("old body"))
+        .unwrap();
+
+    let modified = make_script_response(
+        200,
+        HashMap::new(),
+        Some("a much longer new plaintext body".to_string()),
+    );
+    let result = LoggingHandler::apply_script_response_modify(res, &modified);
+
+    // 바디 교체 시 원본 content-length/encoding 제거(평문을 gzip으로 디코딩하는 손상 방지).
+    assert!(result.headers().get("content-length").is_none());
+    assert!(result.headers().get("content-encoding").is_none());
+    assert!(result.headers().get("transfer-encoding").is_none());
+    assert_eq!(result.headers().get("x-keep").unwrap(), "yes");
+}
+
+#[test]
+fn test_apply_script_response_modify_no_body_keeps_encoding_headers() {
+    let res = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-encoding", "gzip")
+        .body(Body::from("original gzipped"))
+        .unwrap();
+
+    // 바디를 교체하지 않으면 원본 인코딩 헤더는 유지되어야 한다.
+    let modified = make_script_response(200, HashMap::new(), None);
+    let result = LoggingHandler::apply_script_response_modify(res, &modified);
+
+    assert_eq!(result.headers().get("content-encoding").unwrap(), "gzip");
+}


### PR DESCRIPTION
`/code-review max`에서 발견된, 스크립트 훅 경로의 바디 교체 일관성 결함입니다.

## 문제
- `apply_script_request_modify`(onRequest): 헤더를 스크립트가 받은 맵으로 재구성하므로 원본 `content-length`/`content-encoding`이 그대로 남는다. 바디를 바꾸면 길이가 어긋난다.
- `apply_script_response_modify`(onResponse): 원본 `content-encoding: gzip`이 남은 채 스크립트가 평문 바디로 교체하면 클라이언트가 gzip 디코딩을 시도해 **손상**된다.

intercept/breakpoint 경로는 이미 `clear_content_encoding_headers`로 처리하지만 스크립트 경로엔 누락되어 있었습니다(altitude 일관성).

## 수정
두 경로 모두 바디를 교체할 때 `clear_content_encoding_headers`(content-length/content-encoding/transfer-encoding 제거)를 호출.

## 테스트
회귀 4종 추가 + `script_bridge` 27 tests 통과:
- request/response: 바디 교체 시 인코딩·길이 헤더 제거
- request/response: 미교체 시 헤더 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)