### PR TITLE
fix: WebSocket 메시지 상세/목록의 UUID 노출 회귀 수정 (표시용 URL 운반)

### DIFF
--- a/crates/cheolsu_ops/src/context.rs
+++ b/crates/cheolsu_ops/src/context.rs
@@ -226,6 +226,7 @@ mod tests {
     fn make_ws_message(seq: u64) -> WsMessageInfo {
         WsMessageInfo {
             connection_id: "ws://localhost".to_string(),
+            url: "ws://localhost".to_string(),
             sequence: seq,
             direction: WsDirection::ClientToServer,
             message_type: WsMessageType::Text,

--- a/crates/mcp_server/src/tests.rs
+++ b/crates/mcp_server/src/tests.rs
@@ -36,6 +36,7 @@ fn make_empty_request_info() -> RequestInfo {
 fn make_ws_message(connection_id: &str) -> WsMessageInfo {
     WsMessageInfo {
         connection_id: connection_id.to_string(),
+        url: format!("ws://{connection_id}"),
         sequence: 0,
         direction: WsDirection::ClientToServer,
         message_type: proxy_v2_models::WsMessageType::Text,

--- a/crates/mcp_server/tests/integration_test.rs
+++ b/crates/mcp_server/tests/integration_test.rs
@@ -73,6 +73,7 @@ fn make_sse_event(connection_id: &str, seq: u64, data: &str) -> SseEventInfo {
 fn make_ws_message(connection_id: &str, seq: u64, payload: &str) -> WsMessageInfo {
     WsMessageInfo {
         connection_id: connection_id.to_string(),
+        url: format!("ws://{connection_id}"),
         sequence: seq,
         direction: WsDirection::ClientToServer,
         message_type: WsMessageType::Text,

--- a/crates/proxy_daemon/src/session/mod.rs
+++ b/crates/proxy_daemon/src/session/mod.rs
@@ -626,6 +626,7 @@ mod tests {
 
         let ws_msgs = vec![WsMessageInfo {
             connection_id: "ws://example.com/ws".to_string(),
+            url: "ws://example.com/ws".to_string(),
             sequence: 1,
             direction: WsDirection::ClientToServer,
             message_type: WsMessageType::Text,
@@ -677,6 +678,7 @@ mod tests {
         let transactions = vec![make_request_info_with_response()];
         let ws_msgs = vec![WsMessageInfo {
             connection_id: "ws://example.com/ws".to_string(),
+            url: "ws://example.com/ws".to_string(),
             sequence: 0,
             direction: WsDirection::ServerToClient,
             message_type: WsMessageType::Text,

--- a/crates/proxy_daemon/src/ws_handler/handler.rs
+++ b/crates/proxy_daemon/src/ws_handler/handler.rs
@@ -122,6 +122,7 @@ impl LoggingHandler {
     pub(crate) fn emit_ws_event(
         &self,
         connection_id: String,
+        url: String,
         direction: WsDirection,
         message_type: WsMessageType,
         payload: String,
@@ -157,6 +158,7 @@ impl LoggingHandler {
 
         let info = proxy_v2_models::WsMessageInfo {
             connection_id,
+            url,
             sequence,
             direction,
             message_type,

--- a/crates/proxy_daemon/src/ws_handler/tests.rs
+++ b/crates/proxy_daemon/src/ws_handler/tests.rs
@@ -105,6 +105,7 @@ fn emit_ws_event_without_sender_does_nothing() {
     // ws_sender가 None이면 패닉 없이 조용히 반환
     handler.emit_ws_event(
         "conn1".to_string(),
+        "ws://example.com/conn1".to_string(),
         WsDirection::ClientToServer,
         WsMessageType::Text,
         "hello".to_string(),
@@ -161,6 +162,7 @@ fn emit_ws_event_sends_to_channel() {
     };
 
     handler.emit_ws_event(
+        "wss://example.com".to_string(),
         "wss://example.com".to_string(),
         WsDirection::ClientToServer,
         WsMessageType::Text,
@@ -234,6 +236,7 @@ fn emit_ws_event_increments_sequence() {
     for i in 0..3 {
         handler.emit_ws_event(
             "conn".to_string(),
+            "ws://example.com/conn".to_string(),
             WsDirection::ClientToServer,
             WsMessageType::Text,
             "msg".to_string(),

--- a/crates/proxy_daemon/src/ws_handler/trait_impl.rs
+++ b/crates/proxy_daemon/src/ws_handler/trait_impl.rs
@@ -78,6 +78,7 @@ impl WebSocketHandler for LoggingHandler {
 
         self.emit_ws_event(
             connection_id,
+            url,
             direction,
             message_type,
             payload,

--- a/crates/proxy_v2_models/src/websocket.rs
+++ b/crates/proxy_v2_models/src/websocket.rs
@@ -119,8 +119,12 @@ pub enum WsMessageType {
 /// UI로 전달되는 WebSocket 메시지 정보
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct WsMessageInfo {
-    /// WebSocket 연결 ID (URI)
+    /// WebSocket 연결 ID (URI가 아닌 고유 ID — 동일 URI 동시 연결을 구분)
     pub connection_id: String,
+    /// 표시용 연결 URL(스킴 포함). connection_id가 고유 ID로 바뀐 뒤, 메시지만으로
+    /// 연결을 표시할 때 UUID가 노출되지 않도록 메시지가 직접 URL을 운반한다.
+    #[serde(default)]
+    pub url: String,
     /// 메시지 순번
     pub sequence: u64,
     /// 메시지 방향

--- a/desktop/src/entities/websocket/model/types.ts
+++ b/desktop/src/entities/websocket/model/types.ts
@@ -6,6 +6,10 @@ export type WsContentType = "plain" | "socket_io" | "mqtt";
 
 export interface WsMessageInfo {
   connection_id: string;
+  // 표시용 연결 URL(스킴 포함). connection_id가 고유 ID(UUID)로 바뀐 뒤, 메시지만으로
+  // 연결을 표시할 때 UUID 대신 실제 URL을 쓰기 위해 백엔드가 함께 보낸다.
+  // 과거 데이터에는 없을 수 있어 optional.
+  url?: string;
   sequence: number;
   direction: WsDirection;
   message_type: WsMessageType;

--- a/desktop/src/shared/stores/websocket-store.ts
+++ b/desktop/src/shared/stores/websocket-store.ts
@@ -33,7 +33,10 @@ export const useWebSocketStore = create<WebSocketStoreState>()((set) => ({
         if (!connections.has(message.connection_id)) {
           connections.set(message.connection_id, {
             id: message.connection_id,
-            uri: message.connection_id,
+            // connection_id는 이제 고유 ID(UUID)이므로 표시용으로는 메시지가 운반하는
+            // 실제 URL을 우선 사용한다(Connected 이벤트가 유실돼 메시지로만 연결을
+            // 만드는 경우에도 UUID가 노출되지 않도록).
+            uri: message.url || message.connection_id,
             status: "connected",
             startTime: message.time,
             messageCount: 1,

--- a/desktop/src/widgets/websocket-messages/ui/ws-message-detail.tsx
+++ b/desktop/src/widgets/websocket-messages/ui/ws-message-detail.tsx
@@ -52,7 +52,7 @@ export const WsMessageDetail = memo(
         },
         { label: t`Size`, value: formatBytes(message.size) },
         { label: t`Time`, value: formatTimeFull(message.time) },
-        { label: t`Connection`, value: message.connection_id },
+        { label: t`Connection`, value: message.url || message.connection_id },
         { label: t`Sequence`, value: `#${message.sequence}` },
       ];
 


### PR DESCRIPTION
`/code-review max`에서 발견된, conn_id를 UUID로 바꾼 이전 수정의 표시 회귀입니다.

## 문제
`WsMessageInfo`는 `connection_id`만 가지고 URL을 운반하지 않습니다. conn_id가 URI에서 고유 ID(UUID)로 바뀐 뒤:
- **메시지 상세 뷰 "Connection"이 항상 UUID로 표시**(확실한 회귀).
- Connected 이벤트가 채널 포화로 유실되어 메시지만으로 연결을 만들 때, 연결 목록의 uri도 UUID로 표시.

## 수정
- `WsMessageInfo`에 `url` 필드 추가(`#[serde(default)]`로 과거 세션/HAR 호환).
- `emit_ws_event`가 `connection_id`와 함께 `url`을 채움(URL은 호출부에서 이미 사용 가능).
- 프론트: 연결 생성 시 `message.url` 우선 사용(없으면 `connection_id` 폴백), 상세 뷰 Connection도 `url` 우선 표시.

## 테스트
`proxy_daemon` 550, `cheolsu_ops` 45, `proxy_v2_models` 18, mcp 267 등 Rust 전 스위트 + 프론트 585/92 통과. i18n 카탈로그 변동 없음(기존 문자열 재사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)