### PR TITLE
fix: 필터 값의 큰따옴표를 escape해 round-trip 보존

### DIFF
--- a/desktop/src/features/query-filter-editor/lib/query-serializer.test.ts
+++ b/desktop/src/features/query-filter-editor/lib/query-serializer.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "bun:test";
+
+import { parseFilterQuery } from "@/shared/lib/query-parser";
+
+import {
+  serializeBuilderState,
+  parsedQueryToBuilderState,
+  type BuilderState,
+} from "./query-serializer";
+
+// url|= 조건의 값들을 serialize → parse → BuilderState 재구성하여 round-trip 결과를 돌려준다.
+function roundTripUrlValues(values: string[]): string[] {
+  const state: BuilderState = {
+    conditions: [
+      {
+        id: "c1",
+        field: "url",
+        operator: "|=",
+        values,
+        logicalOperator: "and",
+      },
+    ],
+  };
+  const query = serializeBuilderState(state);
+  const parsed = parseFilterQuery(query);
+  const rebuilt = parsedQueryToBuilderState(parsed);
+  const urlCond = rebuilt.conditions.find((c) => c.field === "url" && c.operator === "|=");
+  return urlCond?.values ?? [];
+}
+
+describe("query-serializer round-trip 이스케이프", () => {
+  test("큰따옴표가 포함된 값이 round-trip된다(회귀)", () => {
+    expect(roundTripUrlValues(['a"b'])).toEqual(['a"b']);
+  });
+
+  test("콤마가 포함된 값이 분리되지 않고 round-trip된다", () => {
+    expect(roundTripUrlValues(["a,b"])).toEqual(["a,b"]);
+  });
+
+  test("정규식 백슬래시(\\d)가 보존된다", () => {
+    expect(roundTripUrlValues(["\\d+"])).toEqual(["\\d+"]);
+  });
+
+  test("따옴표·콤마·정규식이 섞인 여러 값이 round-trip된다", () => {
+    expect(roundTripUrlValues(['x"y', "p,q", "\\w+"])).toEqual(['x"y', "p,q", "\\w+"]);
+  });
+});

--- a/desktop/src/features/query-filter-editor/lib/query-serializer.ts
+++ b/desktop/src/features/query-filter-editor/lib/query-serializer.ts
@@ -31,10 +31,13 @@ export function createEmptyCondition(): FilterCondition {
 /**
  * BuilderState → 쿼리 문자열
  */
-// 파서가 콤마를 구분자로 split하므로, 값 내부 콤마를 \,로 escape해야 round-trip이 깨지지 않는다.
-// (백슬래시/따옴표는 기존 동작 유지를 위해 건드리지 않는다 — 정규식 패턴 \d 등 보존)
+// 파서는 값을 큰따옴표로 감싸고 콤마로 split하므로, 값 내부의 큰따옴표(")와 콤마(,)를
+// 각각 \"와 \,로 escape해야 round-trip이 깨지지 않는다(따옴표를 escape하지 않으면 값에
+// "가 있을 때 문자열이 조기에 닫혀 파싱이 어긋난다).
+// 백슬래시는 정규식 패턴(\d 등) 보존을 위해 escape하지 않는다 — 파서도 미지의 escape는
+// 백슬래시를 보존하므로 \d 등은 그대로 round-trip된다.
 function escapeFilterValue(v: string): string {
-  return v.replace(/,/g, "\\,");
+  return v.replace(/"/g, '\\"').replace(/,/g, "\\,");
 }
 
 export function serializeBuilderState(state: BuilderState): string {


### PR DESCRIPTION
`/code-review max`에서 발견된 쿼리 필터 직렬화 결함입니다.

## 문제
`serializeBuilderState`는 값을 큰따옴표로 감싸는데(`field=op"value"`), `escapeFilterValue`가 콤마만 escape하고 **큰따옴표(")는 escape하지 않아** 값에 `"`가 포함되면 문자열이 조기에 닫혀 파싱/round-trip이 깨졌습니다.

## 수정
파서가 `\"`를 인식하므로 직렬화 시 `"` → `\"` escape를 추가. 백슬래시는 정규식 패턴(`\d` 등) 보존을 위해 escape하지 않음(파서도 미지의 escape는 백슬래시를 보존).

## 테스트
round-trip 회귀 4종 추가(따옴표/콤마/정규식 `\d`/혼합), `test:components` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)