### PR TITLE
docs: MCP 도구 문서를 실제 구현(48개)과 동기화

### DIFF
--- a/document/en/features/mcp-server.md
+++ b/document/en/features/mcp-server.md
@@ -70,19 +70,39 @@ With Cheolsu Proxy running, ask your AI assistant a simple question like "What i
 
 ## Available Tools
 
+A total of **48 tools** are provided. The full list by category is below.
+
 ### Traffic Inspection
 
-| Tool                     | Description                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------- |
-| `search_traffic`         | Search captured traffic by host, HTTP method, status code, or URL path          |
-| `get_transaction`        | Get the full request and response (headers and body) for a specific transaction |
-| `get_websocket_messages` | Get captured WebSocket messages, optionally filtered by connection URI          |
+| Tool                     | Description                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| `search_traffic`         | Search captured traffic by host, HTTP method, status code, or URL path              |
+| `get_transaction`        | Get the full request and response (headers and body) for a specific transaction     |
+| `get_websocket_messages` | Get captured WebSocket messages, optionally filtered by connection URI              |
+| `get_sse_events`         | Get captured Server-Sent Events (SSE), optionally filtered by connection URI        |
+| `diff_transactions`      | Compare two transactions (request + response). Useful for regression/before-after   |
+| `proxy_status`           | Check whether the proxy daemon is running and view traffic statistics               |
+| `clear_traffic`          | Clear all captured traffic data from memory                                         |
 
-### Request Sending
+### Analytics
 
-| Tool             | Description                                                                                                    |
-| ---------------- | -------------------------------------------------------------------------------------------------------------- |
-| `replay_request` | Send an HTTP request directly, bypassing the proxy. Useful for testing APIs without triggering intercept rules |
+| Tool                       | Description                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `analyze_performance`      | Analyze slow requests + P50/P95/P99 latency percentiles                            |
+| `analyze_errors`           | Analyze error rates (breakdown by status code and endpoint, recent errors)         |
+| `analyze_endpoints`        | Per-endpoint stats (frequency, avg/P95 response time, error rate, response size)   |
+| `detect_duplicates`        | Detect the same URL called multiple times in a short window (missing caching)       |
+| `detect_n_plus_one`        | Detect N+1 query patterns (same parameterized endpoint called repeatedly)           |
+| `analyze_traffic_timeline` | Request volume, errors, and average latency over time buckets                       |
+| `analyze_full`             | Run all analyses at once and return a comprehensive summary report                  |
+
+### Request Replay
+
+| Tool              | Description                                                                         |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `replay_request`  | Send an HTTP request directly, bypassing the proxy. Useful for testing APIs        |
+| `replay_sequence` | Replay multiple captured transactions in sequence (optional delay between requests) |
+| `advanced_repeat` | Repeat a request with configurable concurrency/delay and return aggregate stats     |
 
 ### Intercept Rule Management
 
@@ -92,12 +112,68 @@ With Cheolsu Proxy running, ask your AI assistant a simple question like "What i
 | `add_rule`    | Add a new intercept rule (block, modify_request, modify_response, map_local, map_remote) |
 | `remove_rule` | Remove an intercept rule by its ID                                                       |
 
-### Proxy Status
+### Breakpoints
 
-| Tool            | Description                                                           |
-| --------------- | --------------------------------------------------------------------- |
-| `proxy_status`  | Check whether the proxy daemon is running and view traffic statistics |
-| `clear_traffic` | Clear all captured traffic data from memory                           |
+| Tool                       | Description                                                                       |
+| -------------------------- | -------------------------------------------------------------------------------- |
+| `list_breakpoints`         | List all breakpoint rules                                                         |
+| `add_breakpoint`           | Add a breakpoint rule (pause matching requests/responses for manual editing)      |
+| `remove_breakpoint`        | Remove a breakpoint rule by its ID                                                |
+| `list_pending_breakpoints` | List currently paused (pending) breakpoints                                       |
+| `resolve_breakpoint`       | Resolve a pending breakpoint (forward / modify_and_forward / drop / abort)        |
+
+### Host Mapping
+
+| Tool                  | Description                                                                       |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `list_host_mappings`  | List all host mappings (DNS spoofing rules)                                       |
+| `add_host_mapping`    | Add a host mapping rule (wildcard support, original Host header preserved)        |
+| `remove_host_mapping` | Remove a host mapping rule by its ID                                              |
+
+### Reverse Proxy
+
+| Tool                        | Description                                                                  |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `list_reverse_proxy_rules`  | List all reverse proxy rules                                                 |
+| `add_reverse_proxy_rule`    | Add a reverse proxy rule (Host pattern → backend server, wildcard support)   |
+| `remove_reverse_proxy_rule` | Remove a reverse proxy rule by its ID                                        |
+
+### Server Replay
+
+| Tool                   | Description                                                                       |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `list_server_replay`   | List all server replay entries                                                    |
+| `add_server_replay`    | Register a captured transaction for server replay (cached response for matches)   |
+| `remove_server_replay` | Remove a server replay entry by its ID                                            |
+| `clear_server_replay`  | Clear all server replay entries                                                   |
+
+### Settings
+
+| Tool                         | Description                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `update_upstream_proxy`      | Configure upstream proxy (forward all traffic through it)                    |
+| `update_throttle`            | Configure network throttling (bytes/sec, simulate slow connections)         |
+| `update_proxy_auth`          | Configure proxy authentication (basic / bearer / apikey)                    |
+| `update_connection_strategy` | Set upstream connection strategy (lazy / eager / eager_with_fallback)        |
+| `update_quick_settings`      | Quick settings (no_caching, block_cookies, no_gzip, block_quic)             |
+| `update_client_certificate`  | Configure mTLS client certificate                                            |
+| `update_ssl_proxying_list`   | Configure SSL proxying list (blacklist/whitelist mode)                       |
+
+### Session & Export
+
+| Tool                    | Description                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `save_session`          | Save captured traffic to a `.cheolsu` session file (`.cheolsu.gz` for gzip)       |
+| `load_session`          | Load a session (`.cheolsu`, `.cheolsu.gz`) or import a HAR (`.har`) (append opt.)  |
+| `export_har`            | Export captured traffic as HAR 1.2 JSON (filter by host/path)                     |
+| `generate_openapi_spec` | Generate an OpenAPI 3.0 specification from captured traffic                       |
+
+### Scripting
+
+| Tool            | Description                                                       |
+| --------------- | ---------------------------------------------------------------- |
+| `load_script`   | Load a JavaScript/TypeScript script (file path or inline code)   |
+| `unload_script` | Unload the currently loaded script                               |
 
 ---
 
@@ -151,4 +227,4 @@ graph TB
 
 The MCP server binary is a standalone process that acts as a client of the proxy daemon. It communicates with the AI assistant over standard input/output using the MCP protocol, and connects to the proxy daemon over a Unix Domain Socket.
 
-The MCP server keeps the most recent 1,000 HTTP transactions and 5,000 WebSocket messages in memory for fast querying. Older data is discarded automatically. Use `clear_traffic` to reset the data manually if needed.
+The MCP server keeps the most recent 1,000 HTTP transactions, 5,000 WebSocket messages, and 5,000 SSE events in memory for fast querying. Older data is discarded automatically. Use `clear_traffic` to reset the data manually if needed.

--- a/document/ko/features/mcp-server.md
+++ b/document/ko/features/mcp-server.md
@@ -75,19 +75,39 @@ claude mcp add cheolsu-proxy -- /path/to/cheolsu-proxy-mcp
 
 ## 제공되는 MCP Tools
 
+총 **48개**의 도구를 제공합니다. 아래는 카테고리별 전체 목록입니다.
+
 ### 트래픽 조회
 
-| Tool                     | 설명                                                         |
-| ------------------------ | ------------------------------------------------------------ |
-| `search_traffic`         | 호스트, HTTP 메서드, 상태코드, URL 경로로 캡처된 트래픽 검색 |
-| `get_transaction`        | 특정 트랜잭션의 요청/응답 헤더 및 바디 상세 조회             |
-| `get_websocket_messages` | 캡처된 WebSocket 메시지 조회 (연결 URI 필터 지원)            |
+| Tool                     | 설명                                                                  |
+| ------------------------ | --------------------------------------------------------------------- |
+| `search_traffic`         | 호스트, HTTP 메서드, 상태코드, URL 경로로 캡처된 트래픽 검색          |
+| `get_transaction`        | 특정 트랜잭션의 요청/응답 헤더 및 바디 상세 조회                      |
+| `get_websocket_messages` | 캡처된 WebSocket 메시지 조회 (연결 URI 필터 지원)                     |
+| `get_sse_events`         | 캡처된 SSE(Server-Sent Events) 조회 (연결 URI 필터 지원)             |
+| `diff_transactions`      | 두 트랜잭션(요청+응답)을 비교해 차이 표시. 회귀 테스트/배포 전후 비교 |
+| `proxy_status`           | 프록시 데몬 상태 및 트래픽 통계 확인                                  |
+| `clear_traffic`          | 메모리에 캡처된 트래픽 데이터 초기화                                  |
 
-### 요청 전송
+### 분석
 
-| Tool             | 설명                                                   |
-| ---------------- | ------------------------------------------------------ |
-| `replay_request` | HTTP 요청을 직접 전송 (프록시 우회). API 테스트에 유용 |
+| Tool                       | 설명                                                                |
+| -------------------------- | ------------------------------------------------------------------- |
+| `analyze_performance`      | 느린 요청 분석 + P50/P95/P99 지연 백분위                            |
+| `analyze_errors`           | 에러율 분석 (상태코드/엔드포인트별 분해, 최근 에러)                 |
+| `analyze_endpoints`        | 엔드포인트별 통계 (호출 빈도, 평균/P95 응답시간, 에러율, 응답 크기) |
+| `detect_duplicates`        | 짧은 시간 내 중복 호출된 동일 URL 탐지 (불필요한 재요청/캐싱 누락)  |
+| `detect_n_plus_one`        | N+1 쿼리 패턴 탐지 (동일 파라미터 엔드포인트의 연속 호출)           |
+| `analyze_traffic_timeline` | 시간 버킷별 요청량·에러·평균 지연 타임라인                          |
+| `analyze_full`             | 위 분석을 모두 실행한 종합 리포트                                   |
+
+### 요청 재전송
+
+| Tool              | 설명                                                            |
+| ----------------- | --------------------------------------------------------------- |
+| `replay_request`  | HTTP 요청을 직접 전송 (프록시 우회). API 테스트에 유용          |
+| `replay_sequence` | 여러 트랜잭션을 순서대로 재전송 (요청 간 지연 옵션)             |
+| `advanced_repeat` | 동일 요청을 동시성/지연 설정으로 반복 후 집계 통계(RPS 등) 반환 |
 
 ### 인터셉트 규칙 관리
 
@@ -97,19 +117,68 @@ claude mcp add cheolsu-proxy -- /path/to/cheolsu-proxy-mcp
 | `add_rule`    | 새 인터셉트 규칙 추가 (block, modify_request, modify_response, map_local, map_remote) |
 | `remove_rule` | ID로 인터셉트 규칙 삭제                                                               |
 
+### 브레이크포인트
+
+| Tool                       | 설명                                                                          |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `list_breakpoints`         | 브레이크포인트 규칙 목록 조회                                                  |
+| `add_breakpoint`           | 브레이크포인트 규칙 추가 (매칭 요청/응답을 수동 편집을 위해 일시정지)          |
+| `remove_breakpoint`        | ID로 브레이크포인트 규칙 삭제                                                  |
+| `list_pending_breakpoints` | 현재 일시정지(대기) 중인 브레이크포인트 목록                                   |
+| `resolve_breakpoint`       | 대기 중 브레이크포인트 처리 (forward / modify_and_forward / drop / abort)      |
+
+### 호스트 매핑
+
+| Tool                  | 설명                                                                    |
+| --------------------- | ----------------------------------------------------------------------- |
+| `list_host_mappings`  | 호스트 매핑(DNS 스푸핑) 규칙 목록 조회                                   |
+| `add_host_mapping`    | 호스트 매핑 규칙 추가 (와일드카드 지원, 원본 Host 헤더 보존)            |
+| `remove_host_mapping` | ID로 호스트 매핑 규칙 삭제                                               |
+
+### 리버스 프록시
+
+| Tool                        | 설명                                                            |
+| --------------------------- | --------------------------------------------------------------- |
+| `list_reverse_proxy_rules`  | 리버스 프록시 규칙 목록 조회                                     |
+| `add_reverse_proxy_rule`    | 리버스 프록시 규칙 추가 (Host 패턴 → 백엔드 서버, 와일드카드 지원) |
+| `remove_reverse_proxy_rule` | ID로 리버스 프록시 규칙 삭제                                     |
+
+### 서버 리플레이
+
+| Tool                   | 설명                                                                       |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `list_server_replay`   | 서버 리플레이 항목 목록 조회                                                |
+| `add_server_replay`    | 캡처된 트랜잭션을 서버 리플레이로 등록 (매칭 요청에 캐시된 응답 반환)       |
+| `remove_server_replay` | ID로 서버 리플레이 항목 삭제                                                |
+| `clear_server_replay`  | 모든 서버 리플레이 항목 초기화                                              |
+
+### 설정
+
+| Tool                         | 설명                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| `update_upstream_proxy`      | 업스트림 프록시 설정 (모든 트래픽을 해당 프록시로 전달)                    |
+| `update_throttle`            | 네트워크 스로틀링 설정 (bytes/sec, 느린 연결 시뮬레이션)                  |
+| `update_proxy_auth`          | 프록시 인증 설정 (basic / bearer / apikey)                                |
+| `update_connection_strategy` | 업스트림 연결 전략 (lazy / eager / eager_with_fallback)                   |
+| `update_quick_settings`      | 빠른 설정 (no_caching, block_cookies, no_gzip, block_quic)               |
+| `update_client_certificate`  | mTLS 클라이언트 인증서 설정                                                |
+| `update_ssl_proxying_list`   | SSL proxying 목록 설정 (blacklist/whitelist 모드)                         |
+
+### 세션 & 익스포트
+
+| Tool                    | 설명                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `save_session`          | 캡처 트래픽을 `.cheolsu` 세션 파일로 저장 (`.cheolsu.gz` 압축 지원)        |
+| `load_session`          | 세션 파일(`.cheolsu`, `.cheolsu.gz`) 또는 HAR(`.har`) 불러오기 (append 옵션) |
+| `export_har`            | 캡처 트래픽을 HAR 1.2 JSON으로 내보내기 (호스트/경로 필터)                 |
+| `generate_openapi_spec` | 캡처 트래픽에서 OpenAPI 3.0 명세 자동 생성                                 |
+
 ### 스크립팅
 
 | Tool            | 설명                                                      |
 | --------------- | --------------------------------------------------------- |
 | `load_script`   | JavaScript/TypeScript 스크립트 로드 (파일 경로 또는 코드) |
 | `unload_script` | 현재 로드된 스크립트 언로드                               |
-
-### 상태 관리
-
-| Tool            | 설명                                 |
-| --------------- | ------------------------------------ |
-| `proxy_status`  | 프록시 데몬 상태 및 트래픽 통계 확인 |
-| `clear_traffic` | 메모리에 캡처된 트래픽 데이터 초기화 |
 
 ---
 
@@ -169,4 +238,4 @@ graph TB
     style C fill:#f3e5f5
 ```
 
-MCP 서버는 프록시 데몬의 또 다른 클라이언트로 동작합니다. 실시간으로 트래픽을 수집하며, 최근 1,000개의 HTTP 트랜잭션과 5,000개의 WebSocket 메시지를 메모리에 유지합니다.
+MCP 서버는 프록시 데몬의 또 다른 클라이언트로 동작합니다. 실시간으로 트래픽을 수집하며, 최근 1,000개의 HTTP 트랜잭션, 5,000개의 WebSocket 메시지, 5,000개의 SSE 이벤트를 메모리에 유지합니다.


### PR DESCRIPTION
문서 전수조사 결과(H1) 반영: MCP 문서가 11개 도구만 나열해 실제 등록된 **48개**와 크게 어긋나 있었습니다.

## 변경
- 카테고리별 전체 48개 도구 목록으로 갱신(트래픽 7, 분석 7, 재전송 3, 인터셉트 3, 브레이크포인트 5, 호스트 매핑 3, 리버스 프록시 3, 서버 리플레이 4, 설정 7, 세션&익스포트 4, 스크립팅 2).
- EN 문서에 누락됐던 **Scripting 섹션 복원** → ko/en 일치(이전 ko 11 / en 9).
- 메모리 보존 한도 설명에 SSE 5,000건 추가(`cheolsu_ops::context::MAX_SSE_EVENTS`와 일치).

도구 이름·설명은 `crates/mcp_server/src/tools/*.rs`의 `#[tool(description=...)]`에서 직접 추출했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)