### PR TITLE
docs: CLI 문서를 실제 clap 정의와 동기화

### DIFF
--- a/document/en/guide/cli.md
+++ b/document/en/guide/cli.md
@@ -17,13 +17,19 @@ cargo build -p cheolsu-cli --release
 cheolsu <subcommand> [options]
 ```
 
+Every command accepts the global `--output` option to choose the output format (`text` default, `json`).
+
+```bash
+cheolsu traffic search --host example.com --output json
+```
+
 ## Subcommands
 
 ### Traffic
 
 ```bash
-# Search captured traffic
-cheolsu traffic search --host example.com --method GET --limit 20
+# Search captured traffic (host/method/status/path/limit filters)
+cheolsu traffic search --host example.com --method GET --status 500 --path /api --limit 20
 
 # Get transaction details
 cheolsu traffic get <transaction-id>
@@ -32,7 +38,7 @@ cheolsu traffic get <transaction-id>
 cheolsu traffic ws --connection-id ws://example.com --limit 50
 
 # View SSE events
-cheolsu traffic sse --limit 50
+cheolsu traffic sse --connection-id https://example.com --limit 50
 
 # Compare two transactions
 cheolsu traffic diff <id-a> <id-b>
@@ -41,28 +47,104 @@ cheolsu traffic diff <id-a> <id-b>
 cheolsu traffic clear
 
 # Generate OpenAPI spec from traffic
-cheolsu traffic openapi --host api.example.com --title "My API"
+cheolsu traffic openapi --host api.example.com --path-prefix /v1 --title "My API"
 ```
 
 ### Rules
+
+The required options depend on `--action-type`.
 
 ```bash
 # List intercept rules
 cheolsu rule list
 
-# Add a block rule
-cheolsu rule add --name "Block ads" --pattern "*.ads.com" --action-type block
+# Block rule (optional custom status/body)
+cheolsu rule add --name "Block ads" --pattern "*.ads.com" --action-type block \
+  --status-code 403 --response-body "blocked"
 
-# Add a map-remote rule
+# Modify-request rule (add/remove headers)
+cheolsu rule add --name "Add auth" --pattern "*api.example.com*" \
+  --action-type modify_request --add-header "Authorization=Bearer token123" \
+  --remove-header "Cookie"
+
+# Modify-response rule
+cheolsu rule add --name "Allow CORS" --pattern "*api.example.com*" \
+  --action-type modify_response --add-header "Access-Control-Allow-Origin=*"
+
+# Map Local — serve the response from a local file
+cheolsu rule add --name "Mock response" --pattern "*api.example.com/users*" \
+  --action-type map_local --file-path ./mock/users.json
+
+# Map Remote
 cheolsu rule add --name "Dev redirect" --pattern "*api.example.com*" \
   --action-type map_remote --target-url "http://localhost:3000" --preserve-path true
 
-# Add a modify-request rule
-cheolsu rule add --name "Add auth" --pattern "*api.example.com*" \
-  --action-type modify_request --add-header "Authorization=Bearer token123"
-
 # Remove a rule
 cheolsu rule remove <rule-id>
+```
+
+### Breakpoints
+
+```bash
+# List breakpoint rules
+cheolsu breakpoint list
+
+# Add a breakpoint (choose request/response phase)
+cheolsu breakpoint add --pattern "*api.example.com*" \
+  --break-on-request true --break-on-response false
+
+# List paused (pending) breakpoints
+cheolsu breakpoint pending
+
+# Resolve a pending breakpoint (forward / modify_and_forward / drop / abort)
+cheolsu breakpoint resolve --id <bp-id> --action modify_and_forward \
+  --header "X-Debug=1" --body '{"patched":true}' --status 200
+
+# Remove a breakpoint
+cheolsu breakpoint remove <bp-id>
+```
+
+### Host Mapping
+
+```bash
+# List host mappings
+cheolsu host-mapping list
+
+# Add a host mapping (source → target, optional ports)
+cheolsu host-mapping add --source-host api.example.com \
+  --target-host 127.0.0.1 --target-port 3000
+
+# Remove a host mapping
+cheolsu host-mapping remove <mapping-id>
+```
+
+### Reverse Proxy
+
+```bash
+# List reverse proxy rules
+cheolsu reverse-proxy list
+
+# Add a rule (Host pattern → backend)
+cheolsu reverse-proxy add --match-host example.com \
+  --backend-scheme http --backend-host 127.0.0.1 --backend-port 8080 \
+  --rewrite-host true
+
+# Remove a rule
+cheolsu reverse-proxy remove <rule-id>
+```
+
+### Server Replay
+
+```bash
+# List server replay entries
+cheolsu server-replay list
+
+# Register a captured transaction for server replay (cached response for matches)
+cheolsu server-replay add <transaction-id>
+
+# Remove an entry / clear all
+cheolsu server-replay remove <entry-id>
+cheolsu server-replay clear
 ```
 
 ### Analysis
@@ -110,26 +192,33 @@ cheolsu replay repeat --method GET --url https://example.com \
 
 ### Settings
 
+> `--enabled`, `--no-caching`, etc. are **boolean flags that take no value**. Add the flag to turn it on, omit it to turn it off (e.g. `--enabled true` is an error).
+
 ```bash
-# Configure upstream proxy
-cheolsu settings upstream-proxy --enabled true --host proxy.corp.com --port 8080
+# Enable upstream proxy (auth optional)
+cheolsu settings upstream-proxy --enabled --host proxy.corp.com --port 8080 \
+  --username user --password pass
 
-# Enable throttling
-cheolsu settings throttle --enabled true --download-rate 50000 --latency-ms 200
+# Disable upstream proxy (omit the flag)
+cheolsu settings upstream-proxy --host proxy.corp.com --port 8080
 
-# Configure proxy authentication
-cheolsu settings proxy-auth --enabled true --method basic --username user --password pass
+# Configure throttling (rates in bytes/sec)
+cheolsu settings throttle --enabled --download-rate 50000 --upload-rate 20000 --latency-ms 200
 
-# Set connection strategy
+# Configure proxy authentication (basic / bearer / apikey)
+cheolsu settings proxy-auth --enabled --method basic --username user --password pass
+cheolsu settings proxy-auth --enabled --method bearer --token "my-token"
+
+# Set connection strategy (lazy / eager / eager_with_fallback)
 cheolsu settings connection-strategy eager
 
-# Quick settings
-cheolsu settings quick --no-caching true --block-cookies true
+# Quick settings (turn on only the flags you need)
+cheolsu settings quick --no-caching --block-cookies --no-gzip --block-quic
 
 # Configure client certificate (mTLS)
-cheolsu settings client-certificate --enabled true --cert-path ./cert.pem --key-path ./key.pem
+cheolsu settings client-certificate --enabled --cert-path ./cert.pem --key-path ./key.pem
 
-# Configure SSL proxying list
+# Configure SSL proxying list (mode: blacklist default / whitelist)
 cheolsu settings ssl-proxying-list --mode whitelist \
   --entry "api.example.com=true" \
   --entry "api.example.com:8443=true"
@@ -138,14 +227,28 @@ cheolsu settings ssl-proxying-list --mode whitelist \
 ### Session
 
 ```bash
-# Save current traffic to a session file
-cheolsu session save ./traffic.cheolsu --name "My Session"
+# Save current traffic to a session file (.cheolsu.gz to gzip, --filter for URL substring filter)
+cheolsu session save ./traffic.cheolsu --name "My Session" \
+  --description "Repro case" --filter example.com
 
-# Load a session file
+# Load a session file (.cheolsu/.cheolsu.gz) or import a HAR (.har)
 cheolsu session load ./traffic.cheolsu
 
 # Load and append to existing traffic
 cheolsu session load ./traffic.cheolsu --append
+```
+
+### Scripts
+
+```bash
+# Load a script from a file
+cheolsu script load --path ./my-script.js
+
+# Load inline code
+cheolsu script load --code "cheolsu.onRequest((req) => ({ action: 'forward' }));"
+
+# Unload the script
+cheolsu script unload
 ```
 
 ### Other
@@ -154,15 +257,19 @@ cheolsu session load ./traffic.cheolsu --append
 # Check proxy status
 cheolsu status
 
-# Export traffic as HAR file
+# Export traffic as HAR file (--host / --path filters)
 cheolsu export-har ./output.har --host example.com
 
 # Launch TUI mode
-cheolsu tui --port 8100
+cheolsu tui --port 8100 --host 0.0.0.0
 
-# Manage scripts
-cheolsu script load --path ./my-script.js
-cheolsu script unload
+# Install / check / uninstall Claude Code skills
+cheolsu install-skills
+cheolsu install-skills --check
+cheolsu uninstall-skills
+
+# Generate shell completion (bash / zsh / fish / powershell)
+cheolsu completion zsh > _cheolsu
 ```
 
 ## Exit Codes

--- a/document/ko/guide/cli.md
+++ b/document/ko/guide/cli.md
@@ -17,13 +17,19 @@ cargo build -p cheolsu-cli --release
 cheolsu <서브커맨드> [옵션]
 ```
 
+모든 커맨드는 전역 `--output` 옵션으로 출력 형식을 선택할 수 있습니다(`text` 기본, `json`).
+
+```bash
+cheolsu traffic search --host example.com --output json
+```
+
 ## 서브커맨드
 
 ### 트래픽
 
 ```bash
-# 캡처된 트래픽 검색
-cheolsu traffic search --host example.com --method GET --limit 20
+# 캡처된 트래픽 검색 (host/method/status/path/limit 필터)
+cheolsu traffic search --host example.com --method GET --status 500 --path /api --limit 20
 
 # 트랜잭션 상세 조회
 cheolsu traffic get <트랜잭션-id>
@@ -32,7 +38,7 @@ cheolsu traffic get <트랜잭션-id>
 cheolsu traffic ws --connection-id ws://example.com --limit 50
 
 # SSE 이벤트 조회
-cheolsu traffic sse --limit 50
+cheolsu traffic sse --connection-id https://example.com --limit 50
 
 # 두 트랜잭션 비교
 cheolsu traffic diff <id-a> <id-b>
@@ -41,28 +47,104 @@ cheolsu traffic diff <id-a> <id-b>
 cheolsu traffic clear
 
 # 트래픽으로부터 OpenAPI 스펙 생성
-cheolsu traffic openapi --host api.example.com --title "My API"
+cheolsu traffic openapi --host api.example.com --path-prefix /v1 --title "My API"
 ```
 
 ### 규칙
+
+`--action-type`에 따라 필요한 옵션이 달라집니다.
 
 ```bash
 # 인터셉트 규칙 목록
 cheolsu rule list
 
-# 차단 규칙 추가
-cheolsu rule add --name "광고 차단" --pattern "*.ads.com" --action-type block
+# 차단 규칙 (커스텀 상태코드/바디 선택)
+cheolsu rule add --name "광고 차단" --pattern "*.ads.com" --action-type block \
+  --status-code 403 --response-body "blocked"
 
-# 원격 매핑 규칙 추가
+# 요청 수정 규칙 (헤더 추가/제거)
+cheolsu rule add --name "인증 추가" --pattern "*api.example.com*" \
+  --action-type modify_request --add-header "Authorization=Bearer token123" \
+  --remove-header "Cookie"
+
+# 응답 수정 규칙
+cheolsu rule add --name "CORS 허용" --pattern "*api.example.com*" \
+  --action-type modify_response --add-header "Access-Control-Allow-Origin=*"
+
+# 로컬 매핑 (Map Local) — 응답을 로컬 파일로 대체
+cheolsu rule add --name "목 응답" --pattern "*api.example.com/users*" \
+  --action-type map_local --file-path ./mock/users.json
+
+# 원격 매핑 (Map Remote)
 cheolsu rule add --name "개발 리다이렉트" --pattern "*api.example.com*" \
   --action-type map_remote --target-url "http://localhost:3000" --preserve-path true
 
-# 요청 수정 규칙 추가
-cheolsu rule add --name "인증 추가" --pattern "*api.example.com*" \
-  --action-type modify_request --add-header "Authorization=Bearer token123"
-
 # 규칙 제거
 cheolsu rule remove <규칙-id>
+```
+
+### 브레이크포인트
+
+```bash
+# 브레이크포인트 목록
+cheolsu breakpoint list
+
+# 브레이크포인트 추가 (요청/응답 단계 선택)
+cheolsu breakpoint add --pattern "*api.example.com*" \
+  --break-on-request true --break-on-response false
+
+# 대기 중(일시정지)인 브레이크포인트 조회
+cheolsu breakpoint pending
+
+# 대기 중 브레이크포인트 처리 (forward / modify_and_forward / drop / abort)
+cheolsu breakpoint resolve --id <bp-id> --action modify_and_forward \
+  --header "X-Debug=1" --body '{"patched":true}' --status 200
+
+# 브레이크포인트 제거
+cheolsu breakpoint remove <bp-id>
+```
+
+### 호스트 매핑
+
+```bash
+# 호스트 매핑 목록
+cheolsu host-mapping list
+
+# 호스트 매핑 추가 (source → target, 포트 선택)
+cheolsu host-mapping add --source-host api.example.com \
+  --target-host 127.0.0.1 --target-port 3000
+
+# 호스트 매핑 제거
+cheolsu host-mapping remove <매핑-id>
+```
+
+### 리버스 프록시
+
+```bash
+# 리버스 프록시 규칙 목록
+cheolsu reverse-proxy list
+
+# 규칙 추가 (Host 패턴 → 백엔드)
+cheolsu reverse-proxy add --match-host example.com \
+  --backend-scheme http --backend-host 127.0.0.1 --backend-port 8080 \
+  --rewrite-host true
+
+# 규칙 제거
+cheolsu reverse-proxy remove <규칙-id>
+```
+
+### 서버 리플레이
+
+```bash
+# 서버 리플레이 항목 목록
+cheolsu server-replay list
+
+# 캡처된 트랜잭션을 서버 리플레이로 등록 (매칭 요청에 캐시 응답 반환)
+cheolsu server-replay add <트랜잭션-id>
+
+# 항목 제거 / 전체 초기화
+cheolsu server-replay remove <항목-id>
+cheolsu server-replay clear
 ```
 
 ### 분석
@@ -110,26 +192,33 @@ cheolsu replay repeat --method GET --url https://example.com \
 
 ### 설정
 
+> `--enabled`, `--no-caching` 등은 **값을 받지 않는 플래그**입니다. 켜려면 플래그를 붙이고, 끄려면 생략하세요(예: `--enabled true`는 오류).
+
 ```bash
-# 업스트림 프록시 설정
-cheolsu settings upstream-proxy --enabled true --host proxy.corp.com --port 8080
+# 업스트림 프록시 활성화 (인증 선택)
+cheolsu settings upstream-proxy --enabled --host proxy.corp.com --port 8080 \
+  --username user --password pass
 
-# 쓰로틀링 설정
-cheolsu settings throttle --enabled true --download-rate 50000 --latency-ms 200
+# 업스트림 프록시 비활성화 (플래그 생략)
+cheolsu settings upstream-proxy --host proxy.corp.com --port 8080
 
-# 프록시 인증 설정
-cheolsu settings proxy-auth --enabled true --method basic --username user --password pass
+# 쓰로틀링 설정 (rate 단위: bytes/sec)
+cheolsu settings throttle --enabled --download-rate 50000 --upload-rate 20000 --latency-ms 200
 
-# 연결 전략 설정
+# 프록시 인증 설정 (basic / bearer / apikey)
+cheolsu settings proxy-auth --enabled --method basic --username user --password pass
+cheolsu settings proxy-auth --enabled --method bearer --token "my-token"
+
+# 연결 전략 설정 (lazy / eager / eager_with_fallback)
 cheolsu settings connection-strategy eager
 
-# 빠른 설정
-cheolsu settings quick --no-caching true --block-cookies true
+# 빠른 설정 (필요한 플래그만 켜기)
+cheolsu settings quick --no-caching --block-cookies --no-gzip --block-quic
 
 # 클라이언트 인증서 설정 (mTLS)
-cheolsu settings client-certificate --enabled true --cert-path ./cert.pem --key-path ./key.pem
+cheolsu settings client-certificate --enabled --cert-path ./cert.pem --key-path ./key.pem
 
-# SSL 프록싱 리스트 설정
+# SSL 프록싱 리스트 설정 (mode: blacklist 기본 / whitelist)
 cheolsu settings ssl-proxying-list --mode whitelist \
   --entry "api.example.com=true" \
   --entry "api.example.com:8443=true"
@@ -138,14 +227,28 @@ cheolsu settings ssl-proxying-list --mode whitelist \
 ### 세션
 
 ```bash
-# 현재 트래픽을 세션 파일로 저장
-cheolsu session save ./traffic.cheolsu --name "내 세션"
+# 현재 트래픽을 세션 파일로 저장 (.cheolsu.gz로 압축, --filter로 URL 부분 일치 필터)
+cheolsu session save ./traffic.cheolsu --name "내 세션" \
+  --description "재현 케이스" --filter example.com
 
-# 세션 파일 로드
+# 세션 파일(.cheolsu/.cheolsu.gz) 또는 HAR(.har) 로드
 cheolsu session load ./traffic.cheolsu
 
 # 기존 트래픽에 추가로 로드
 cheolsu session load ./traffic.cheolsu --append
+```
+
+### 스크립트
+
+```bash
+# 파일에서 스크립트 로드
+cheolsu script load --path ./my-script.js
+
+# 인라인 코드로 로드
+cheolsu script load --code "cheolsu.onRequest((req) => ({ action: 'forward' }));"
+
+# 스크립트 언로드
+cheolsu script unload
 ```
 
 ### 기타
@@ -154,15 +257,19 @@ cheolsu session load ./traffic.cheolsu --append
 # 프록시 상태 확인
 cheolsu status
 
-# HAR 파일로 내보내기
+# HAR 파일로 내보내기 (--host / --path 필터)
 cheolsu export-har ./output.har --host example.com
 
 # TUI 모드 실행
-cheolsu tui --port 8100
+cheolsu tui --port 8100 --host 0.0.0.0
 
-# 스크립트 관리
-cheolsu script load --path ./my-script.js
-cheolsu script unload
+# Claude Code 스킬 설치 / 설치 상태 확인 / 제거
+cheolsu install-skills
+cheolsu install-skills --check
+cheolsu uninstall-skills
+
+# Shell completion 스크립트 생성 (bash / zsh / fish / powershell)
+cheolsu completion zsh > _cheolsu
 ```
 
 ## 종료 코드


### PR DESCRIPTION
문서 전수조사(H2) 반영.

## 주요 수정
- **bool 플래그 예제 오류**: settings의 `--enabled true` 등 5개 예제가 실제로 파싱 실패(값을 받지 않는 플래그). `--enabled`(켜기)/생략(끄기)로 정정.
- **누락 커맨드 그룹 추가**: `breakpoint`, `host-mapping`, `reverse-proxy`, `server-replay`, `install-skills`/`uninstall-skills`, `completion`.
- **누락 옵션 보강**: 전역 `--output`, `traffic search --status/--path`, `rule add` 액션별 옵션, `session save --filter/--description`, `settings` 전체 옵션, `traffic openapi --path-prefix`.

커맨드/플래그는 `crates/cli/src/main.rs`의 clap 정의에서 직접 추출했습니다. ko/en 동일 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)