### PR TITLE
docs: 스크립팅·SSE 문서를 실제 API와 동기화

### DIFF
--- a/document/en/features/scripting.md
+++ b/document/en/features/scripting.md
@@ -200,11 +200,13 @@ Called before a WebSocket message is forwarded. The handler receives a message o
 
 **Message object:**
 
-| Property    | Type    | Description                    |
-| ----------- | ------- | ------------------------------ |
-| `direction` | string  | `"to_server"` or `"to_client"` |
-| `payload`   | string  | Message content                |
-| `is_binary` | boolean | Whether the message is binary  |
+| Property        | Type    | Description                    |
+| --------------- | ------- | ------------------------------ |
+| `connection_id` | string  | Unique connection ID           |
+| `url`           | string  | Connection URL                 |
+| `direction`     | string  | `"to_server"` or `"to_client"` |
+| `payload`       | string  | Message content                |
+| `is_binary`     | boolean | Whether the message is binary  |
 
 **Return values:**
 
@@ -219,15 +221,53 @@ return { action: "modify", payload: "new content", is_binary: false };
 return { action: "drop" };
 ```
 
+### cheolsu.onSSEMessage(handler)
+
+Called before a Server-Sent Events (SSE) event is forwarded to the client. The handler receives an event object.
+
+**Event object:**
+
+| Property        | Type           | Description                          |
+| --------------- | -------------- | ------------------------------------ |
+| `connection_id` | string         | Unique connection ID                 |
+| `event_type`    | string \| null | Value of the `event:` field (or null) |
+| `data`          | string         | Event data                           |
+| `id`            | string \| null | Value of the `id:` field (or null)   |
+
+**Return values:**
+
+| action      | Description                  | Extra fields |
+| ----------- | ---------------------------- | ------------ |
+| `"forward"` | Forward the event unchanged  | none         |
+| `"drop"`    | Drop the event (not sent)    | none         |
+
+> SSE does not support modifying event content (`modify`) — only forward or drop.
+
+```javascript
+cheolsu.onSSEMessage((event) => {
+  // Drop keep-alive ping events, forward the rest
+  if (event.event_type === "ping") {
+    return { action: "drop" };
+  }
+  return { action: "forward" };
+});
+```
+
 ---
 
 ## Supported File Types
 
 Scripts can be written in JavaScript or TypeScript:
 
-- `.js`, `.ts`, `.mjs`, `.mts`
+- `.js`, `.mjs`, `.ts`, `.tsx`
 
-TypeScript is automatically transpiled using oxc. No build step is required.
+TypeScript (`.ts`/`.tsx`) is automatically transpiled using oxc. No build step is required.
+
+## Execution Limits
+
+- **Timeout**: each hook is limited to 30 seconds. If exceeded (e.g. an infinite loop), V8 execution is forcibly terminated and the hook is treated as pass-through.
+- **Memory**: the V8 heap is limited to roughly 4MB–64MB.
+- **Sandbox**: external I/O APIs such as `fetch`, `require`/`import`, `fs`, `process`, `Buffer`, `crypto`, and `Worker` are not exposed. Only `console.*` and timers (`setTimeout`/`setInterval`) are available.
 
 ---
 
@@ -268,6 +308,7 @@ Logs appear in real time, making it easy to trace script behavior as traffic flo
 | `cheolsu.onRequest(handler)`                           | Register HTTP request hook (sync/async)      |
 | `cheolsu.onResponse(handler)`                          | Register HTTP response hook (sync/async)     |
 | `cheolsu.onWebSocketMessage(handler)`                  | Register WebSocket message hook (sync/async) |
+| `cheolsu.onSSEMessage(handler)`                        | Register SSE event hook (sync/async)         |
 | `console.log/warn/error/info/debug()`                  | Console logging                              |
 | `setTimeout(callback, delay)`                          | Delayed execution                            |
 | `clearTimeout(id)`                                     | Cancel timeout                               |

--- a/document/en/features/sse.md
+++ b/document/en/features/sse.md
@@ -44,7 +44,19 @@ Shows all events for a selected connection in chronological order.
 
 ### Scripting Integration
 
-Use the `cheolsu.onSseEvent` hook to programmatically process SSE events. Events can be modified or filtered (dropped).
+Use the `cheolsu.onSSEMessage` hook to programmatically process SSE events. Events can be passed through (`forward`) or filtered out (`drop`). (Modifying event content is not supported.)
+
+The callback receives an event object of the form `{ connection_id, event_type, data, id }`.
+
+```js
+cheolsu.onSSEMessage((event) => {
+  // Drop keep-alive ping events, forward the rest
+  if (event.event_type === "ping") {
+    return { action: "drop" };
+  }
+  return { action: "forward" };
+});
+```
 
 ---
 

--- a/document/ko/features/scripting.md
+++ b/document/ko/features/scripting.md
@@ -16,8 +16,14 @@ Cheolsu Proxy의 스크립팅 엔진은 Deno Core(V8) 기반의 JavaScript/TypeS
 
 ## 지원 파일 형식
 
-- `.js`, `.ts`, `.mjs`, `.mts`
-- TypeScript는 oxc 기반으로 자동 트랜스파일됩니다. 별도의 컴파일 단계 없이 TypeScript 파일을 바로 사용할 수 있습니다.
+- `.js`, `.mjs`, `.ts`, `.tsx`
+- TypeScript(`.ts`/`.tsx`)는 oxc 기반으로 자동 트랜스파일됩니다. 별도의 컴파일 단계 없이 바로 사용할 수 있습니다.
+
+## 실행 제약
+
+- **타임아웃**: 각 훅 실행은 30초로 제한됩니다. 무한 루프 등으로 초과하면 V8 실행이 강제 종료되고 해당 훅은 통과 처리됩니다.
+- **메모리**: V8 힙은 약 4MB~64MB로 제한됩니다.
+- **샌드박스**: `fetch`, `require`/`import`, `fs`, `process`, `Buffer`, `crypto`, `Worker` 등 외부 I/O API는 노출되지 않습니다. `console.*`과 타이머(`setTimeout`/`setInterval`)만 사용할 수 있습니다.
 
 ---
 
@@ -269,11 +275,13 @@ WebSocket 메시지가 전달되기 전에 호출됩니다.
 
 **handler 파라미터**: `message` 객체
 
-| 필드        | 타입    | 설명                             |
-| ----------- | ------- | -------------------------------- |
-| `direction` | string  | `"to_server"` 또는 `"to_client"` |
-| `payload`   | string  | 메시지 내용                      |
-| `is_binary` | boolean | 바이너리 메시지 여부             |
+| 필드            | 타입    | 설명                             |
+| --------------- | ------- | -------------------------------- |
+| `connection_id` | string  | 연결 고유 ID                     |
+| `url`           | string  | 연결 URL                         |
+| `direction`     | string  | `"to_server"` 또는 `"to_client"` |
+| `payload`       | string  | 메시지 내용                      |
+| `is_binary`     | boolean | 바이너리 메시지 여부             |
 
 **반환값**:
 
@@ -293,6 +301,38 @@ cheolsu.onWebSocketMessage((message) => {
 
   // 메시지 버림
   return { action: "drop" };
+});
+```
+
+### cheolsu.onSSEMessage(handler)
+
+SSE(Server-Sent Events) 이벤트가 클라이언트로 전달되기 전에 호출됩니다.
+
+**handler 파라미터**: `event` 객체
+
+| 필드            | 타입             | 설명                            |
+| --------------- | ---------------- | ------------------------------- |
+| `connection_id` | string           | 연결 고유 ID                    |
+| `event_type`    | string \| null   | `event:` 필드 값 (없으면 null)  |
+| `data`          | string           | 이벤트 데이터                   |
+| `id`            | string \| null   | `id:` 필드 값 (없으면 null)     |
+
+**반환값**:
+
+| action      | 설명                          | 추가 필드 |
+| ----------- | ----------------------------- | --------- |
+| `"forward"` | 이벤트를 그대로 전달          | 없음      |
+| `"drop"`    | 이벤트를 버림 (전달하지 않음) | 없음      |
+
+> SSE는 이벤트 내용 수정(`modify`)을 지원하지 않습니다. 통과 또는 드롭만 가능합니다.
+
+```javascript
+cheolsu.onSSEMessage((event) => {
+  // keep-alive 핑 이벤트는 버리고 나머지는 통과
+  if (event.event_type === "ping") {
+    return { action: "drop" };
+  }
+  return { action: "forward" };
 });
 ```
 
@@ -335,6 +375,7 @@ clearInterval(id);
 | `cheolsu.onRequest(handler)`                           | HTTP 요청 훅 등록 (sync/async)        |
 | `cheolsu.onResponse(handler)`                          | HTTP 응답 훅 등록 (sync/async)        |
 | `cheolsu.onWebSocketMessage(handler)`                  | WebSocket 메시지 훅 등록 (sync/async) |
+| `cheolsu.onSSEMessage(handler)`                        | SSE 이벤트 훅 등록 (sync/async)       |
 | `console.log/warn/error/info/debug()`                  | 콘솔 로깅                             |
 | `setTimeout(callback, delay)`                          | 지연 실행                             |
 | `clearTimeout(id)`                                     | 타이머 취소                           |

--- a/document/ko/features/sse.md
+++ b/document/ko/features/sse.md
@@ -44,7 +44,19 @@ SSE 표준에 따라 각 이벤트의 다음 필드를 파싱합니다:
 
 ### 스크립팅 연동
 
-`cheolsu.onSseEvent` 훅을 사용하면 SSE 이벤트를 프로그래밍 방식으로 처리할 수 있습니다. 이벤트를 수정하거나 특정 이벤트를 필터링(drop)할 수 있습니다.
+`cheolsu.onSSEMessage` 훅을 사용하면 SSE 이벤트를 프로그래밍 방식으로 처리할 수 있습니다. 이벤트를 그대로 통과(`forward`)시키거나 특정 이벤트를 필터링(`drop`)할 수 있습니다. (이벤트 내용 수정은 지원하지 않습니다.)
+
+콜백은 `{ connection_id, event_type, data, id }` 형태의 이벤트 객체를 받습니다.
+
+```js
+cheolsu.onSSEMessage((event) => {
+  // keep-alive 핑 이벤트는 버리고 나머지는 통과
+  if (event.event_type === "ping") {
+    return { action: "drop" };
+  }
+  return { action: "forward" };
+});
+```
 
 ---
 


### PR DESCRIPTION
문서 전수조사(H3) 반영.

## 수정
- **SSE 훅 이름 오류**: `cheolsu.onSseEvent` → 실제 `cheolsu.onSSEMessage`(그대로 쓰면 `TypeError`). "이벤트 수정(modify)" 표현 제거 — `SseAction`은 `forward`/`drop`만 지원.
- **scripting.md에 `onSSEMessage` 훅 문서 추가**(이벤트 객체 `{connection_id, event_type, data, id}`, 반환값, 예제) + API 레퍼런스 등재.
- **WebSocket message 필드 보강**: `connection_id`, `url` 추가(`ScriptWsMessage`와 일치).
- **지원 확장자 정정**: `.tsx` 추가 / `.mts` 제거(loader 화이트리스트 기준).
- **실행 제약 문서화**: 30초 타임아웃, V8 힙 4~64MB, 샌드박스 노출 API.

근거: `crates/scripting/src/{runtime.js,types.rs,engine}`. ko/en 동일 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)