### PR TITLE
docs: 설치 가이드를 실제 빌드/아티팩트와 동기화

### DIFF
--- a/document/en/guide/installation.md
+++ b/document/en/guide/installation.md
@@ -6,22 +6,22 @@ Getting Cheolsu Proxy installed and running on your machine.
 
 ## System Requirements
 
-| Platform                          | Status      |
-| --------------------------------- | ----------- |
-| **macOS** (Apple Silicon & Intel) | Supported   |
-| **Windows**                       | Coming soon |
-| **Linux**                         | Coming soon |
+| Platform                         | Status      |
+| -------------------------------- | ----------- |
+| **macOS** (Apple Silicon)        | Supported   |
+| **macOS** (Intel / x64)          | Not built   |
+| **Windows**                      | Coming soon |
+| **Linux**                        | Coming soon |
 
 Cheolsu Proxy is a native desktop application built with Rust and Tauri, so it runs with minimal resource overhead compared to Electron-based alternatives. There are no runtime dependencies like Java or Python to install.
 
 ## Download
 
-Download the latest release from the [GitHub Releases](https://github.com/ohah/cheolsu-proxy/releases) page. Choose the `.dmg` file that matches your Mac's architecture:
+Download the latest release from the [GitHub Releases](https://github.com/ohah/cheolsu-proxy/releases) page:
 
-- **Apple Silicon** (M1/M2/M3/M4): `cheolsu-proxy_x.x.x_aarch64.dmg`
-- **Intel**: `cheolsu-proxy_x.x.x_x64.dmg`
+- **Apple Silicon** (M1/M2/M3/M4): `Cheolsu.Proxy_x.x.x_aarch64.dmg`
 
-> Not sure which Mac you have? Click the Apple menu and select **About This Mac**. If the Chip field says "Apple M1" or similar, choose the Apple Silicon build.
+> Only the Apple Silicon (aarch64) build is currently published. An Intel (x64) build is not provided.
 
 ## macOS Installation
 
@@ -43,6 +43,12 @@ To open it anyway:
 
 You only need to do this once. Subsequent launches will work normally.
 
+> The current build is not Apple-notarized/signed. If it still won't open, remove the quarantine attribute from the Terminal:
+>
+> ```bash
+> xattr -cr "/Applications/Cheolsu Proxy.app"
+> ```
+
 ## Three Ways to Use Cheolsu Proxy
 
 Cheolsu Proxy ships with three interfaces, all powered by the same underlying proxy daemon:
@@ -58,10 +64,12 @@ A terminal-based interface for developers who prefer working in the command line
 To run the TUI:
 
 ```bash
-cheolsu-proxy-tui
+cheolsu-tui
 ```
 
-> The TUI binary is bundled alongside the desktop app. If it is not in your PATH, you can find it inside the application bundle or in the same directory as the main binary.
+If you have the CLI installed, you can also launch it via `cheolsu tui --port 8100`.
+
+> The TUI binary (`cheolsu-tui`) is bundled with the desktop app as a sidecar. If it is not in your PATH, find it inside the application bundle, or build it from source with `cargo build -p cheolsu-proxy-tui --release`.
 
 ### 3. MCP Server
 

--- a/document/ko/guide/installation.md
+++ b/document/ko/guide/installation.md
@@ -9,7 +9,7 @@ Cheolsu Proxy를 설치하고 첫 실행까지의 과정을 안내합니다.
 ### macOS
 
 - **운영체제**: macOS 12 (Monterey) 이상
-- **아키텍처**: Apple Silicon (M1/M2/M3/M4) 및 Intel 모두 지원
+- **아키텍처**: Apple Silicon (M1/M2/M3/M4). Intel(x64) 빌드는 현재 제공되지 않습니다.
 - **디스크 공간**: 최소 200MB 이상의 여유 공간
 - **권한**: 프록시 설정 변경을 위한 관리자 권한 필요
 
@@ -24,11 +24,10 @@ Cheolsu Proxy를 설치하고 첫 실행까지의 과정을 안내합니다.
 최신 버전은 GitHub Releases 페이지에서 다운로드할 수 있습니다.
 
 1. [GitHub Releases](https://github.com/ohah/cheolsu-proxy/releases) 페이지에 접속합니다
-2. 최신 릴리즈의 Assets 섹션에서 운영체제에 맞는 파일을 다운로드합니다
+2. 최신 릴리즈의 Assets 섹션에서 파일을 다운로드합니다
    - **macOS (Apple Silicon)**: `Cheolsu.Proxy_x.x.x_aarch64.dmg`
-   - **macOS (Intel)**: `Cheolsu.Proxy_x.x.x_x64.dmg`
 
-> 본인의 Mac이 Apple Silicon인지 Intel인지 확인하려면, 좌측 상단 Apple 메뉴 → **이 Mac에 관하여**에서 칩 정보를 확인하세요.
+> 현재 빌드는 Apple Silicon(aarch64)만 제공됩니다. Intel(x64) 빌드는 제공되지 않습니다.
 
 ---
 
@@ -54,6 +53,12 @@ Cheolsu Proxy를 처음 실행하면 macOS Gatekeeper가 실행을 차단할 수
 
 또는 **시스템 설정 → 개인정보 보호 및 보안** 하단에서 "확인 없이 열기" 옵션을 통해 허용할 수도 있습니다.
 
+> 현재 빌드는 Apple 공증/서명이 적용되어 있지 않습니다. 위 방법으로도 열리지 않으면 터미널에서 quarantine 속성을 제거할 수 있습니다.
+>
+> ```bash
+> xattr -cr "/Applications/Cheolsu Proxy.app"
+> ```
+
 ---
 
 ## 인터페이스 소개
@@ -76,13 +81,19 @@ Tauri 기반의 데스크톱 애플리케이션입니다. 트래픽 테이블, �
 
 ## TUI 실행 방법
 
-TUI는 터미널에서 별도의 바이너리로 실행합니다. Desktop GUI와 동일한 프록시 데몬에 연결되므로, 두 인터페이스를 동시에 사용할 수도 있습니다.
+TUI는 터미널에서 `cheolsu-tui` 바이너리로 실행합니다. Desktop GUI와 동일한 프록시 데몬에 연결되므로, 두 인터페이스를 동시에 사용할 수도 있습니다.
 
 ```bash
-cheolsu-proxy-tui
+cheolsu-tui
 ```
 
-> TUI 바이너리는 Desktop 앱과 별도로 제공됩니다. GitHub Releases에서 TUI 바이너리를 확인하세요.
+CLI를 설치했다면 `cheolsu tui`로도 실행할 수 있습니다.
+
+```bash
+cheolsu tui --port 8100
+```
+
+> TUI 바이너리(`cheolsu-tui`)는 Desktop 앱 번들에 사이드카로 포함되어 있습니다. 터미널에서 직접 실행하려면 앱 번들 내부의 바이너리를 PATH에 추가하거나 소스에서 빌드(`cargo build -p cheolsu-proxy-tui --release`)하세요.
 
 ---
 


### PR DESCRIPTION
문서 전수조사(H4) 반영. `release.yml`은 `aarch64-apple-darwin` 단일 타깃만 빌드하고 실제 릴리스 자산도 Apple Silicon dmg뿐입니다.

## 수정
- **존재하지 않는 Intel(x64) 안내 제거**: 아키텍처/플랫폼 표/다운로드 항목.
- **EN dmg 파일명 정정**: `cheolsu-proxy_..._x64.dmg` → `Cheolsu.Proxy_x.x.x_aarch64.dmg`(실제 자산명).
- **TUI 정정**: 실행 바이너리 `cheolsu-proxy-tui` → `cheolsu-tui`, 배포는 GitHub Releases 별도 배포가 아니라 **데스크톱 앱 사이드카 번들**(`tauri.conf.json` externalBin). `cheolsu tui`/소스 빌드 안내 추가.
- **Gatekeeper**: 미서명 빌드용 `xattr -cr` 대안 추가(릴리스 노트와 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)