### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "cheolsu-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "cheolsu_ops",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "cheolsu-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "cheolsu-proxy-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cheolsu_ops",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "cheolsu-proxy-tui"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "cheolsu_ops"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "http 1.4.1",
  "parking_lot",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "proxy_daemon"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "proxy_v2_models"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -7045,7 +7045,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scripting"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "deno_core",
  "oxc_allocator",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "desktop": {
       "name": "cheolsu-proxy",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@base-ui/react": "latest",
         "@hookform/resolvers": "latest",

--- a/crates/cheolsu_ops/Cargo.toml
+++ b/crates/cheolsu_ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheolsu_ops"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [features]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheolsu-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [[bin]]

--- a/crates/mcp_server/Cargo.toml
+++ b/crates/mcp_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheolsu-proxy-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/crates/proxy_daemon/Cargo.toml
+++ b/crates/proxy_daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy_daemon"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/proxy_v2_models/Cargo.toml
+++ b/crates/proxy_v2_models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy_v2_models"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/proxy_v2_models/src/har/builders.rs
+++ b/crates/proxy_v2_models/src/har/builders.rs
@@ -137,7 +137,7 @@ pub fn build_har(transactions: &[RequestInfo]) -> Har {
             version: "1.2".to_string(),
             creator: HarCreator {
                 name: "Cheolsu Proxy".to_string(),
-                version: "0.1.1".to_string(),
+                version: "0.1.2".to_string(),
             },
             entries,
         },

--- a/crates/scripting/Cargo.toml
+++ b/crates/scripting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scripting"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheolsu-proxy-tui"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [[bin]]

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheolsu-proxy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cheolsu-proxy"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Tauri App"
 authors = ["ohah", "jinjoo-dev", "wontaezia", "emanuele-em"]
 license = "MIT"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cheolsu Proxy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.cheolsu-proxy",
   "build": {
     "beforeDevCommand": "bash build-mcp.sh && bun run dev",

--- a/desktop/src/features/har-export/lib/har-export.ts
+++ b/desktop/src/features/har-export/lib/har-export.ts
@@ -244,7 +244,7 @@ export async function buildHarLog(transactions: HttpTransaction[]): Promise<HarL
   return {
     log: {
       version: "1.2",
-      creator: { name: "Cheolsu Proxy", version: "0.1.1" },
+      creator: { name: "Cheolsu Proxy", version: "0.1.2" },
       entries,
     },
   };

--- a/desktop/src/pages/tray-panel/ui/tray-panel.tsx
+++ b/desktop/src/pages/tray-panel/ui/tray-panel.tsx
@@ -120,7 +120,7 @@ export function TrayPanel() {
         <div className="tray-header" data-tauri-drag-region>
           <div className="tray-header-left">
             <span className="tray-title">Cheolsu Proxy</span>
-            <span className="tray-version">v0.1.1</span>
+            <span className="tray-version">v0.1.2</span>
           </div>
           <div className="tray-header-right">
             <Circle

--- a/document/en/features/mcp-server.md
+++ b/document/en/features/mcp-server.md
@@ -74,33 +74,33 @@ A total of **48 tools** are provided. The full list by category is below.
 
 ### Traffic Inspection
 
-| Tool                     | Description                                                                          |
-| ------------------------ | ----------------------------------------------------------------------------------- |
-| `search_traffic`         | Search captured traffic by host, HTTP method, status code, or URL path              |
-| `get_transaction`        | Get the full request and response (headers and body) for a specific transaction     |
-| `get_websocket_messages` | Get captured WebSocket messages, optionally filtered by connection URI              |
-| `get_sse_events`         | Get captured Server-Sent Events (SSE), optionally filtered by connection URI        |
-| `diff_transactions`      | Compare two transactions (request + response). Useful for regression/before-after   |
-| `proxy_status`           | Check whether the proxy daemon is running and view traffic statistics               |
-| `clear_traffic`          | Clear all captured traffic data from memory                                         |
+| Tool                     | Description                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `search_traffic`         | Search captured traffic by host, HTTP method, status code, or URL path            |
+| `get_transaction`        | Get the full request and response (headers and body) for a specific transaction   |
+| `get_websocket_messages` | Get captured WebSocket messages, optionally filtered by connection URI            |
+| `get_sse_events`         | Get captured Server-Sent Events (SSE), optionally filtered by connection URI      |
+| `diff_transactions`      | Compare two transactions (request + response). Useful for regression/before-after |
+| `proxy_status`           | Check whether the proxy daemon is running and view traffic statistics             |
+| `clear_traffic`          | Clear all captured traffic data from memory                                       |
 
 ### Analytics
 
-| Tool                       | Description                                                                         |
-| -------------------------- | ---------------------------------------------------------------------------------- |
-| `analyze_performance`      | Analyze slow requests + P50/P95/P99 latency percentiles                            |
-| `analyze_errors`           | Analyze error rates (breakdown by status code and endpoint, recent errors)         |
-| `analyze_endpoints`        | Per-endpoint stats (frequency, avg/P95 response time, error rate, response size)   |
-| `detect_duplicates`        | Detect the same URL called multiple times in a short window (missing caching)       |
-| `detect_n_plus_one`        | Detect N+1 query patterns (same parameterized endpoint called repeatedly)           |
-| `analyze_traffic_timeline` | Request volume, errors, and average latency over time buckets                       |
-| `analyze_full`             | Run all analyses at once and return a comprehensive summary report                  |
+| Tool                       | Description                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------- |
+| `analyze_performance`      | Analyze slow requests + P50/P95/P99 latency percentiles                          |
+| `analyze_errors`           | Analyze error rates (breakdown by status code and endpoint, recent errors)       |
+| `analyze_endpoints`        | Per-endpoint stats (frequency, avg/P95 response time, error rate, response size) |
+| `detect_duplicates`        | Detect the same URL called multiple times in a short window (missing caching)    |
+| `detect_n_plus_one`        | Detect N+1 query patterns (same parameterized endpoint called repeatedly)        |
+| `analyze_traffic_timeline` | Request volume, errors, and average latency over time buckets                    |
+| `analyze_full`             | Run all analyses at once and return a comprehensive summary report               |
 
 ### Request Replay
 
 | Tool              | Description                                                                         |
-| ----------------- | ---------------------------------------------------------------------------------- |
-| `replay_request`  | Send an HTTP request directly, bypassing the proxy. Useful for testing APIs        |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| `replay_request`  | Send an HTTP request directly, bypassing the proxy. Useful for testing APIs         |
 | `replay_sequence` | Replay multiple captured transactions in sequence (optional delay between requests) |
 | `advanced_repeat` | Repeat a request with configurable concurrency/delay and return aggregate stats     |
 
@@ -114,66 +114,66 @@ A total of **48 tools** are provided. The full list by category is below.
 
 ### Breakpoints
 
-| Tool                       | Description                                                                       |
-| -------------------------- | -------------------------------------------------------------------------------- |
-| `list_breakpoints`         | List all breakpoint rules                                                         |
-| `add_breakpoint`           | Add a breakpoint rule (pause matching requests/responses for manual editing)      |
-| `remove_breakpoint`        | Remove a breakpoint rule by its ID                                                |
-| `list_pending_breakpoints` | List currently paused (pending) breakpoints                                       |
-| `resolve_breakpoint`       | Resolve a pending breakpoint (forward / modify_and_forward / drop / abort)        |
+| Tool                       | Description                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `list_breakpoints`         | List all breakpoint rules                                                    |
+| `add_breakpoint`           | Add a breakpoint rule (pause matching requests/responses for manual editing) |
+| `remove_breakpoint`        | Remove a breakpoint rule by its ID                                           |
+| `list_pending_breakpoints` | List currently paused (pending) breakpoints                                  |
+| `resolve_breakpoint`       | Resolve a pending breakpoint (forward / modify_and_forward / drop / abort)   |
 
 ### Host Mapping
 
-| Tool                  | Description                                                                       |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `list_host_mappings`  | List all host mappings (DNS spoofing rules)                                       |
-| `add_host_mapping`    | Add a host mapping rule (wildcard support, original Host header preserved)        |
-| `remove_host_mapping` | Remove a host mapping rule by its ID                                              |
+| Tool                  | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `list_host_mappings`  | List all host mappings (DNS spoofing rules)                                |
+| `add_host_mapping`    | Add a host mapping rule (wildcard support, original Host header preserved) |
+| `remove_host_mapping` | Remove a host mapping rule by its ID                                       |
 
 ### Reverse Proxy
 
-| Tool                        | Description                                                                  |
-| --------------------------- | --------------------------------------------------------------------------- |
-| `list_reverse_proxy_rules`  | List all reverse proxy rules                                                 |
-| `add_reverse_proxy_rule`    | Add a reverse proxy rule (Host pattern → backend server, wildcard support)   |
-| `remove_reverse_proxy_rule` | Remove a reverse proxy rule by its ID                                        |
+| Tool                        | Description                                                                |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `list_reverse_proxy_rules`  | List all reverse proxy rules                                               |
+| `add_reverse_proxy_rule`    | Add a reverse proxy rule (Host pattern → backend server, wildcard support) |
+| `remove_reverse_proxy_rule` | Remove a reverse proxy rule by its ID                                      |
 
 ### Server Replay
 
-| Tool                   | Description                                                                       |
-| ---------------------- | -------------------------------------------------------------------------------- |
-| `list_server_replay`   | List all server replay entries                                                    |
-| `add_server_replay`    | Register a captured transaction for server replay (cached response for matches)   |
-| `remove_server_replay` | Remove a server replay entry by its ID                                            |
-| `clear_server_replay`  | Clear all server replay entries                                                   |
+| Tool                   | Description                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| `list_server_replay`   | List all server replay entries                                                  |
+| `add_server_replay`    | Register a captured transaction for server replay (cached response for matches) |
+| `remove_server_replay` | Remove a server replay entry by its ID                                          |
+| `clear_server_replay`  | Clear all server replay entries                                                 |
 
 ### Settings
 
-| Tool                         | Description                                                                  |
-| ---------------------------- | --------------------------------------------------------------------------- |
-| `update_upstream_proxy`      | Configure upstream proxy (forward all traffic through it)                    |
-| `update_throttle`            | Configure network throttling (bytes/sec, simulate slow connections)         |
-| `update_proxy_auth`          | Configure proxy authentication (basic / bearer / apikey)                    |
-| `update_connection_strategy` | Set upstream connection strategy (lazy / eager / eager_with_fallback)        |
-| `update_quick_settings`      | Quick settings (no_caching, block_cookies, no_gzip, block_quic)             |
-| `update_client_certificate`  | Configure mTLS client certificate                                            |
-| `update_ssl_proxying_list`   | Configure SSL proxying list (blacklist/whitelist mode)                       |
+| Tool                         | Description                                                           |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `update_upstream_proxy`      | Configure upstream proxy (forward all traffic through it)             |
+| `update_throttle`            | Configure network throttling (bytes/sec, simulate slow connections)   |
+| `update_proxy_auth`          | Configure proxy authentication (basic / bearer / apikey)              |
+| `update_connection_strategy` | Set upstream connection strategy (lazy / eager / eager_with_fallback) |
+| `update_quick_settings`      | Quick settings (no_caching, block_cookies, no_gzip, block_quic)       |
+| `update_client_certificate`  | Configure mTLS client certificate                                     |
+| `update_ssl_proxying_list`   | Configure SSL proxying list (blacklist/whitelist mode)                |
 
 ### Session & Export
 
 | Tool                    | Description                                                                       |
-| ----------------------- | -------------------------------------------------------------------------------- |
+| ----------------------- | --------------------------------------------------------------------------------- |
 | `save_session`          | Save captured traffic to a `.cheolsu` session file (`.cheolsu.gz` for gzip)       |
-| `load_session`          | Load a session (`.cheolsu`, `.cheolsu.gz`) or import a HAR (`.har`) (append opt.)  |
+| `load_session`          | Load a session (`.cheolsu`, `.cheolsu.gz`) or import a HAR (`.har`) (append opt.) |
 | `export_har`            | Export captured traffic as HAR 1.2 JSON (filter by host/path)                     |
 | `generate_openapi_spec` | Generate an OpenAPI 3.0 specification from captured traffic                       |
 
 ### Scripting
 
-| Tool            | Description                                                       |
-| --------------- | ---------------------------------------------------------------- |
-| `load_script`   | Load a JavaScript/TypeScript script (file path or inline code)   |
-| `unload_script` | Unload the currently loaded script                               |
+| Tool            | Description                                                    |
+| --------------- | -------------------------------------------------------------- |
+| `load_script`   | Load a JavaScript/TypeScript script (file path or inline code) |
+| `unload_script` | Unload the currently loaded script                             |
 
 ---
 

--- a/document/en/features/scripting.md
+++ b/document/en/features/scripting.md
@@ -227,19 +227,19 @@ Called before a Server-Sent Events (SSE) event is forwarded to the client. The h
 
 **Event object:**
 
-| Property        | Type           | Description                          |
-| --------------- | -------------- | ------------------------------------ |
-| `connection_id` | string         | Unique connection ID                 |
+| Property        | Type           | Description                           |
+| --------------- | -------------- | ------------------------------------- |
+| `connection_id` | string         | Unique connection ID                  |
 | `event_type`    | string \| null | Value of the `event:` field (or null) |
-| `data`          | string         | Event data                           |
-| `id`            | string \| null | Value of the `id:` field (or null)   |
+| `data`          | string         | Event data                            |
+| `id`            | string \| null | Value of the `id:` field (or null)    |
 
 **Return values:**
 
-| action      | Description                  | Extra fields |
-| ----------- | ---------------------------- | ------------ |
-| `"forward"` | Forward the event unchanged  | none         |
-| `"drop"`    | Drop the event (not sent)    | none         |
+| action      | Description                 | Extra fields |
+| ----------- | --------------------------- | ------------ |
+| `"forward"` | Forward the event unchanged | none         |
+| `"drop"`    | Drop the event (not sent)   | none         |
 
 > SSE does not support modifying event content (`modify`) — only forward or drop.
 

--- a/document/en/guide/installation.md
+++ b/document/en/guide/installation.md
@@ -6,12 +6,12 @@ Getting Cheolsu Proxy installed and running on your machine.
 
 ## System Requirements
 
-| Platform                         | Status      |
-| -------------------------------- | ----------- |
-| **macOS** (Apple Silicon)        | Supported   |
-| **macOS** (Intel / x64)          | Not built   |
-| **Windows**                      | Coming soon |
-| **Linux**                        | Coming soon |
+| Platform                  | Status      |
+| ------------------------- | ----------- |
+| **macOS** (Apple Silicon) | Supported   |
+| **macOS** (Intel / x64)   | Not built   |
+| **Windows**               | Coming soon |
+| **Linux**                 | Coming soon |
 
 Cheolsu Proxy is a native desktop application built with Rust and Tauri, so it runs with minimal resource overhead compared to Electron-based alternatives. There are no runtime dependencies like Java or Python to install.
 

--- a/document/en/releases/index.md
+++ b/document/en/releases/index.md
@@ -4,6 +4,31 @@ Version-by-version update history for Cheolsu Proxy.
 
 ## Latest Release
 
+### v0.1.2 (2026-06-14)
+
+Maintenance release with a full dependency upgrade, a large batch of security and stability bug fixes, and documentation accuracy improvements.
+
+📦 [Download from GitHub Release](https://github.com/ohah/cheolsu-proxy/releases/tag/v0.1.2)
+
+:::warning Unsigned Build
+This build is not code-signed. After copying to `/Applications`, run the following in Terminal:
+
+```bash
+xattr -cr /Applications/Cheolsu\ Proxy.app
+```
+
+You only need to do this once.
+:::
+
+**Highlights**:
+
+- Upgraded Rust/JavaScript dependencies across the board, including the scripting engine (deno_core/V8/oxc), MCP (rmcp), and Tauri.
+- Fixed High-severity security issues (certificate SAN validation, mTLS fail-open) and hardened against panics, request-integrity bugs, and decompression bombs.
+- Protected the daemon from runaway scripts (infinite loops / memory exhaustion) and cleaned up hook timeout / forced-termination races.
+- Fixed an infinite-block regression when intercepting plaintext GET-over-CONNECT (ws://) and a slow-client DoS vector.
+- Fixed many bugs across SSE/WebSocket UTF-8 handling, multipart size calculation, system proxy restore, and throttle preset persistence.
+- Synced the MCP tools (48), CLI, scripting/SSE, and installation documentation with the actual implementation.
+
 ### v0.1.1 (2026-04-30)
 
 Maintenance release with safer TLS auto-passthrough behavior, certificate-generation stability work, desktop/TUI/CLI usability improvements, documentation updates, and CI cleanup.

--- a/document/ko/features/mcp-server.md
+++ b/document/ko/features/mcp-server.md
@@ -84,7 +84,7 @@ claude mcp add cheolsu-proxy -- /path/to/cheolsu-proxy-mcp
 | `search_traffic`         | 호스트, HTTP 메서드, 상태코드, URL 경로로 캡처된 트래픽 검색          |
 | `get_transaction`        | 특정 트랜잭션의 요청/응답 헤더 및 바디 상세 조회                      |
 | `get_websocket_messages` | 캡처된 WebSocket 메시지 조회 (연결 URI 필터 지원)                     |
-| `get_sse_events`         | 캡처된 SSE(Server-Sent Events) 조회 (연결 URI 필터 지원)             |
+| `get_sse_events`         | 캡처된 SSE(Server-Sent Events) 조회 (연결 URI 필터 지원)              |
 | `diff_transactions`      | 두 트랜잭션(요청+응답)을 비교해 차이 표시. 회귀 테스트/배포 전후 비교 |
 | `proxy_status`           | 프록시 데몬 상태 및 트래픽 통계 확인                                  |
 | `clear_traffic`          | 메모리에 캡처된 트래픽 데이터 초기화                                  |
@@ -119,59 +119,59 @@ claude mcp add cheolsu-proxy -- /path/to/cheolsu-proxy-mcp
 
 ### 브레이크포인트
 
-| Tool                       | 설명                                                                          |
-| -------------------------- | ----------------------------------------------------------------------------- |
-| `list_breakpoints`         | 브레이크포인트 규칙 목록 조회                                                  |
-| `add_breakpoint`           | 브레이크포인트 규칙 추가 (매칭 요청/응답을 수동 편집을 위해 일시정지)          |
-| `remove_breakpoint`        | ID로 브레이크포인트 규칙 삭제                                                  |
-| `list_pending_breakpoints` | 현재 일시정지(대기) 중인 브레이크포인트 목록                                   |
-| `resolve_breakpoint`       | 대기 중 브레이크포인트 처리 (forward / modify_and_forward / drop / abort)      |
+| Tool                       | 설명                                                                      |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `list_breakpoints`         | 브레이크포인트 규칙 목록 조회                                             |
+| `add_breakpoint`           | 브레이크포인트 규칙 추가 (매칭 요청/응답을 수동 편집을 위해 일시정지)     |
+| `remove_breakpoint`        | ID로 브레이크포인트 규칙 삭제                                             |
+| `list_pending_breakpoints` | 현재 일시정지(대기) 중인 브레이크포인트 목록                              |
+| `resolve_breakpoint`       | 대기 중 브레이크포인트 처리 (forward / modify_and_forward / drop / abort) |
 
 ### 호스트 매핑
 
-| Tool                  | 설명                                                                    |
-| --------------------- | ----------------------------------------------------------------------- |
-| `list_host_mappings`  | 호스트 매핑(DNS 스푸핑) 규칙 목록 조회                                   |
-| `add_host_mapping`    | 호스트 매핑 규칙 추가 (와일드카드 지원, 원본 Host 헤더 보존)            |
-| `remove_host_mapping` | ID로 호스트 매핑 규칙 삭제                                               |
+| Tool                  | 설명                                                         |
+| --------------------- | ------------------------------------------------------------ |
+| `list_host_mappings`  | 호스트 매핑(DNS 스푸핑) 규칙 목록 조회                       |
+| `add_host_mapping`    | 호스트 매핑 규칙 추가 (와일드카드 지원, 원본 Host 헤더 보존) |
+| `remove_host_mapping` | ID로 호스트 매핑 규칙 삭제                                   |
 
 ### 리버스 프록시
 
-| Tool                        | 설명                                                            |
-| --------------------------- | --------------------------------------------------------------- |
-| `list_reverse_proxy_rules`  | 리버스 프록시 규칙 목록 조회                                     |
+| Tool                        | 설명                                                               |
+| --------------------------- | ------------------------------------------------------------------ |
+| `list_reverse_proxy_rules`  | 리버스 프록시 규칙 목록 조회                                       |
 | `add_reverse_proxy_rule`    | 리버스 프록시 규칙 추가 (Host 패턴 → 백엔드 서버, 와일드카드 지원) |
-| `remove_reverse_proxy_rule` | ID로 리버스 프록시 규칙 삭제                                     |
+| `remove_reverse_proxy_rule` | ID로 리버스 프록시 규칙 삭제                                       |
 
 ### 서버 리플레이
 
-| Tool                   | 설명                                                                       |
-| ---------------------- | -------------------------------------------------------------------------- |
-| `list_server_replay`   | 서버 리플레이 항목 목록 조회                                                |
-| `add_server_replay`    | 캡처된 트랜잭션을 서버 리플레이로 등록 (매칭 요청에 캐시된 응답 반환)       |
-| `remove_server_replay` | ID로 서버 리플레이 항목 삭제                                                |
-| `clear_server_replay`  | 모든 서버 리플레이 항목 초기화                                              |
+| Tool                   | 설명                                                                  |
+| ---------------------- | --------------------------------------------------------------------- |
+| `list_server_replay`   | 서버 리플레이 항목 목록 조회                                          |
+| `add_server_replay`    | 캡처된 트랜잭션을 서버 리플레이로 등록 (매칭 요청에 캐시된 응답 반환) |
+| `remove_server_replay` | ID로 서버 리플레이 항목 삭제                                          |
+| `clear_server_replay`  | 모든 서버 리플레이 항목 초기화                                        |
 
 ### 설정
 
-| Tool                         | 설명                                                                      |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| `update_upstream_proxy`      | 업스트림 프록시 설정 (모든 트래픽을 해당 프록시로 전달)                    |
-| `update_throttle`            | 네트워크 스로틀링 설정 (bytes/sec, 느린 연결 시뮬레이션)                  |
-| `update_proxy_auth`          | 프록시 인증 설정 (basic / bearer / apikey)                                |
-| `update_connection_strategy` | 업스트림 연결 전략 (lazy / eager / eager_with_fallback)                   |
-| `update_quick_settings`      | 빠른 설정 (no_caching, block_cookies, no_gzip, block_quic)               |
-| `update_client_certificate`  | mTLS 클라이언트 인증서 설정                                                |
-| `update_ssl_proxying_list`   | SSL proxying 목록 설정 (blacklist/whitelist 모드)                         |
+| Tool                         | 설명                                                       |
+| ---------------------------- | ---------------------------------------------------------- |
+| `update_upstream_proxy`      | 업스트림 프록시 설정 (모든 트래픽을 해당 프록시로 전달)    |
+| `update_throttle`            | 네트워크 스로틀링 설정 (bytes/sec, 느린 연결 시뮬레이션)   |
+| `update_proxy_auth`          | 프록시 인증 설정 (basic / bearer / apikey)                 |
+| `update_connection_strategy` | 업스트림 연결 전략 (lazy / eager / eager_with_fallback)    |
+| `update_quick_settings`      | 빠른 설정 (no_caching, block_cookies, no_gzip, block_quic) |
+| `update_client_certificate`  | mTLS 클라이언트 인증서 설정                                |
+| `update_ssl_proxying_list`   | SSL proxying 목록 설정 (blacklist/whitelist 모드)          |
 
 ### 세션 & 익스포트
 
-| Tool                    | 설명                                                                       |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `save_session`          | 캡처 트래픽을 `.cheolsu` 세션 파일로 저장 (`.cheolsu.gz` 압축 지원)        |
+| Tool                    | 설명                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `save_session`          | 캡처 트래픽을 `.cheolsu` 세션 파일로 저장 (`.cheolsu.gz` 압축 지원)          |
 | `load_session`          | 세션 파일(`.cheolsu`, `.cheolsu.gz`) 또는 HAR(`.har`) 불러오기 (append 옵션) |
-| `export_har`            | 캡처 트래픽을 HAR 1.2 JSON으로 내보내기 (호스트/경로 필터)                 |
-| `generate_openapi_spec` | 캡처 트래픽에서 OpenAPI 3.0 명세 자동 생성                                 |
+| `export_har`            | 캡처 트래픽을 HAR 1.2 JSON으로 내보내기 (호스트/경로 필터)                   |
+| `generate_openapi_spec` | 캡처 트래픽에서 OpenAPI 3.0 명세 자동 생성                                   |
 
 ### 스크립팅
 

--- a/document/ko/features/scripting.md
+++ b/document/ko/features/scripting.md
@@ -310,12 +310,12 @@ SSE(Server-Sent Events) 이벤트가 클라이언트로 전달되기 전에 호�
 
 **handler 파라미터**: `event` 객체
 
-| 필드            | 타입             | 설명                            |
-| --------------- | ---------------- | ------------------------------- |
-| `connection_id` | string           | 연결 고유 ID                    |
-| `event_type`    | string \| null   | `event:` 필드 값 (없으면 null)  |
-| `data`          | string           | 이벤트 데이터                   |
-| `id`            | string \| null   | `id:` 필드 값 (없으면 null)     |
+| 필드            | 타입           | 설명                           |
+| --------------- | -------------- | ------------------------------ |
+| `connection_id` | string         | 연결 고유 ID                   |
+| `event_type`    | string \| null | `event:` 필드 값 (없으면 null) |
+| `data`          | string         | 이벤트 데이터                  |
+| `id`            | string \| null | `id:` 필드 값 (없으면 null)    |
 
 **반환값**:
 

--- a/document/ko/releases/index.md
+++ b/document/ko/releases/index.md
@@ -4,6 +4,31 @@ Cheolsu Proxy의 버전별 업데이트 내역을 확인할 수 있습니다.
 
 ## 최신 릴리즈
 
+### v0.1.2 (2026-06-14)
+
+의존성 전면 버전업과 대규모 보안·안정성 버그 수정, 문서 정합성 개선을 포함한 유지보수 릴리즈입니다.
+
+📦 [GitHub Release 다운로드](https://github.com/ohah/cheolsu-proxy/releases/tag/v0.1.2)
+
+:::warning 서명되지 않은 빌드
+이 빌드는 코드 서명이 되어 있지 않습니다. `/Applications`에 복사한 후 터미널에서 다음 명령어를 실행하세요:
+
+```bash
+xattr -cr /Applications/Cheolsu\ Proxy.app
+```
+
+최초 1회만 실행하면 됩니다.
+:::
+
+**주요 변경사항**:
+
+- 스크립팅 엔진(deno_core/V8/oxc), MCP(rmcp), Tauri 등 Rust/JavaScript 의존성을 전면 버전업했습니다.
+- 인증서 SAN 검증, mTLS fail-open 등 보안 결함과 패닉·요청 무결성·압축 폭탄 방어를 포함한 High 버그를 수정했습니다.
+- 스크립팅 엔진의 무한 루프·메모리 폭주 시 데몬을 보호하고, 훅 타임아웃/강제 종료 race를 정리했습니다.
+- 평문 GET-over-CONNECT(ws://) 인터셉트 시 무한 블록 회귀와 슬로우 클라이언트 DoS를 방지했습니다.
+- SSE/WebSocket UTF-8 처리, multipart 크기 계산, 시스템 프록시 복원, 스로틀 프리셋 유실 등 다수 버그를 수정했습니다.
+- MCP 도구(48개)·CLI·스크립팅/SSE·설치 문서를 실제 구현과 동기화했습니다.
+
 ### v0.1.1 (2026-04-30)
 
 TLS 자동 패스스루 안전성 강화, 인증서 생성 안정화, 데스크톱/TUI/CLI 사용성 개선, 문서 및 CI 환경 정리를 포함한 유지보수 릴리즈입니다.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheolsu-proxy-root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "A simple Man In The Middle proxy built with Rust and Tauri",
   "keywords": [


### PR DESCRIPTION
v0.1.1 → **v0.1.2** 릴리스 버전 범프 + 릴리즈 노트.

## 변경
- 워크스페이스 크레이트 7종 + `desktop/src-tauri` Cargo.toml, `Cargo.lock`, `package.json`(루트/desktop), `bun.lock`, `tauri.conf.json` 버전 갱신(`proxyapi_v2`는 fork 버전 `0.23.0` 유지).
- 소스 내 버전 문자열(HAR creator, tray 버전) 갱신.
- 릴리즈 노트(ko/en)에 **v0.1.2 (2026-06-14)** 항목 추가.
- (선행 커밋) 이전 문서 PR에서 누락됐던 markdown 표 정렬을 oxfmt로 정규화.

## v0.1.2 주요 내용 (v0.1.1 이후)
- 의존성 전면 버전업(deno_core/V8/oxc, rmcp, Tauri 등)
- High 보안/안정성 수정(인증서 SAN, mTLS fail-open, 패닉/요청 무결성/압축 폭탄)
- 스크립팅 엔진 보호(무한 루프·메모리, 타임아웃/강제 종료 race)
- 평문 GET-over-CONNECT 무한 블록 회귀 + 슬로우 클라이언트 DoS 방지
- SSE/WS/multipart/시스템 프록시/스로틀 프리셋 등 다수 버그 수정
- MCP(48)·CLI·스크립팅/SSE·설치 문서 동기화

머지 후 `v0.1.2` 태그를 푸시하면 `release.yml`이 Apple Silicon 빌드(draft 릴리스)를, `deploy-docs`가 GitHub Pages를 갱신합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)