### PR TITLE
fix: MCP tool_router 데드코드 제거 (릴리스 빌드 실패 수정)

### DIFF
--- a/crates/mcp_server/src/server.rs
+++ b/crates/mcp_server/src/server.rs
@@ -11,7 +11,6 @@ use crate::store::Store;
 pub(crate) struct CheolsuMcpServer {
     pub(crate) store: Store,
     pub(crate) daemon_conn: Arc<TokioMutex<Option<DaemonConnection>>>,
-    tool_router: ToolRouter<Self>,
 }
 
 impl CheolsuMcpServer {
@@ -19,7 +18,6 @@ impl CheolsuMcpServer {
         Self {
             store,
             daemon_conn: Arc::new(TokioMutex::new(conn)),
-            tool_router: Self::tool_router(),
         }
     }
 


### PR DESCRIPTION
v0.1.2 릴리스 빌드가 `beforeBuildCommand`(build-mcp.sh)에서 exit 101로 실패했습니다.

## 원인
`build-mcp.sh`는 `-D warnings`로 사이드카(mcp/tui)를 빌드합니다. `crates/mcp_server/src/server.rs`의 `CheolsuMcpServer.tool_router` 필드가 **dead code**(생성자에서만 세팅, Clone만 읽음)라 경고 → 에러로 빌드 실패.

rmcp 1.7의 `#[tool_handler]`는 기본적으로 `self.tool_router` 필드가 아니라 **`Self::tool_router()` 함수**를 호출하므로(rmcp-macros 1.7.0 문서: "Defaults to `Self::tool_router()`") 필드는 불필요합니다.

## 수정
`tool_router` 필드와 생성자 초기화를 제거. 도구 라우팅은 `Self::tool_router()`로 그대로 동작.

## 검증
- `RUSTFLAGS="-D warnings"`로 `cheolsu-proxy-mcp`, `cheolsu-proxy-tui` 빌드 통과(릴리스 strict 재현).
- MCP 테스트 93건 통과(라우팅 정상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)